### PR TITLE
docs: remove proof of concept note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Quarto Extensions Listing
 
-> [!NOTE]
-> This repository is a proof of concept.
-
 This is a listing of Quarto extensions using GitHub API to retrieve information from the repositories.
 
 To add your extension to this list, please submit a pull request to this repository by adding your extension repository at the bottom of [`extensions/quarto-extensions.csv`](https://github.com/mcanouil/quarto-extensions/edit/main/extensions/quarto-extensions.csv).

--- a/index.qmd
+++ b/index.qmd
@@ -9,10 +9,6 @@ about:
       aria-label: "GitHub logo linking to mcanouil/quarto-extensions repository"
 ---
 
-:::{.callout-note}
-This is a proof of concept.
-:::
-
 This is a listing of Quarto extensions hosted on GitHub and using GitHub API to retrieve information from the repositories.
 
 You can submit a new extension by making a pull request to the [GitHub repository](https://github.com/mcanouil/quarto-extensions/edit/main/extensions/quarto-extensions.csv).


### PR DESCRIPTION
This PR removes the proof of concept note from the Quarto Extensions Listing. The note is no longer necessary as the repository is now fully functional.