### PR TITLE
chore: Add a few extensions

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -55,6 +55,8 @@ shortcodes-filters,shafayetShafee/hide-comment
 shortcodes-filters,shafayetShafee/nameref
 shortcodes-filters,shafayetShafee/material-icons
 shortcodes-filters,coatless/quarto-webr
+shortcodes-filters,coatless-quarto/pyodide
+shortcodes-filters,coatless-quarto/adsense
 shortcodes-filters,shafayetShafee/black-formatter
 shortcodes-filters,jmgirard/embedpdf
 shortcodes-filters,ute/custom-numbered-blocks
@@ -137,5 +139,5 @@ shortcodes-filters,mloubout/critic-markup
 formats,mps9506/quarto-lapreprint
 formats,gl-eb/minimal-doc
 shortcodes-filters,gadenbuie/quarto-now
-formats,coatless-quarto/hsnr-revealjs
 shortcodes-filters,coatless-quarto/embedio
+shortcodes-filters,gadenbuie/countdown


### PR DESCRIPTION
I deleted `formats,coatless-quarto/hsnr-revealjs` as that's covered by `formats,produnis/hsnr-revealjs`