### PR TITLE
style: Categories as Upper Case

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -45,6 +45,13 @@ format:
       source: false
       toggle: false
       caption: none
+    include-in-header:
+      text: |
+        <style>
+        .category {
+          text-transform: uppercase;
+        }
+        </style>
     include-after-body:
       text: |
         <script type="text/javascript">


### PR DESCRIPTION
Update the styling of categories to display them in upper case. This change adds a CSS rule to transform the text of category labels to uppercase.