### PR TITLE
ci: Remove category from topics/description CSV structure

### DIFF
--- a/.github/workflows/check-extensions.yml
+++ b/.github/workflows/check-extensions.yml
@@ -55,7 +55,7 @@ jobs:
           if [[ -n "${add_extension}" ]]; then
             gh pr diff ${NUMBER} --patch | awk '/\+\+\+ b\/extensions\/quarto-extensions\.csv/{flag=1; next} flag && /^\+/' | sed 's/^+//' > diff.patch
             if [[ -s diff.patch ]]; then
-              while IFS=, read -r category repo; do
+              while IFS=, read -r repo; do
                 repo_topics=$(gh repo view --json repositoryTopics "${repo}" --jq ".repositoryTopics")
                 if [[ -z "${repo_topics}" ]]; then
                   echo "::error file=extensions/quarto-extensions.csv::Repository '${repo}' is missing topics!"
@@ -79,7 +79,7 @@ jobs:
           if [[ -n "${add_extension}" ]]; then
             gh pr diff ${NUMBER} --patch | awk '/\+\+\+ b\/extensions\/quarto-extensions\.csv/{flag=1; next} flag && /^\+/' | sed 's/^+//' > diff.patch
             if [[ -s diff.patch ]]; then
-              while IFS=, read -r category repo; do
+              while IFS=, read -r repo; do
                 repo_description=$(gh repo view --json description "${repo}" --jq ".description")
                 if [[ -z "${repo_description}" ]]; then
                   echo "::error file=extensions/quarto-extensions.csv::Repository '${repo}' is missing description!"


### PR DESCRIPTION
This pull request removes the category field from the topics/description CSV structure. The category field was causing issues when checking extensions, so it has been removed to simplify the structure and improve the extension checking process.