### PR TITLE
chore: Remove duplicated extension

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -128,7 +128,6 @@ clearmatics/qreacto
 data-intuitive/quarto-d2
 kdheepak/quarto-svgbob
 andrewheiss/quarto-wordcount
-coatless/quarto-illinois
 produnis/quarto-timer
 dragonstyle/share-post
 bcdavasconcelos/citetools


### PR DESCRIPTION
This pull request removes the duplicated extension "coatless/quarto-illinois" from the `quarto-extensions.csv` file.