### PR TITLE
Add gadenbuie/quarto-base64

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -186,3 +186,4 @@ restlessronin/gfm-strip-disallowed
 parmsam/quarto-quiz
 pat-alt/quarto-julia
 r-wasm/quarto-drop
+gadenbuie/quarto-base64


### PR DESCRIPTION
Adds a new `{{< base64 >}}` and `{{< base64-data >}}` shortcode from [gadenbuie/quarto-base64](https://pkg.garrickadenbuie.com/quarto-base64/) to the list of extensions.