### PR TITLE
fix: display of zero star author count

### DIFF
--- a/assets/ejs/authors.ejs
+++ b/assets/ejs/authors.ejs
@@ -15,16 +15,12 @@
         <a href="<%= item.url %>" target="_blank" class="text-decoration: none;"><iconify-icon inline="true" role="img" icon="octicon:mark-github-16" aria-label="Icon mark-github-16 from octicon Iconify.design set." title="Icon mark-github-16 from octicon Iconify.design set."></iconify-icon></a>
       </span>
       <% } %>
-      <% if (item.stars) { %>
       <span>
         <iconify-icon inline="true" role="img" icon="octicon:star-16" aria-label="Icon star-16 from octicon Iconify.design set." title="Icon star-16 from octicon Iconify.design set."></iconify-icon> <%= item.stars %>
       </span>
-      <% } %>
-      <% if (item.extensions) { %>
       <span>
         <iconify-icon inline="true" role="img" icon="octicon:repo-16" aria-label="Icon repo-16 from octicon Iconify.design set." title="Icon repo-16 from octicon Iconify.design set."></iconify-icon> <%= item.extensions %>
       </span>
-      <% } %>
       <% } %>
     </p>
   </div>


### PR DESCRIPTION
This pull request fixes the issue where the zero star author count was not being displayed. The problem was caused by a conditional statement that was incorrectly checking for the presence of the `stars` property. This pull request removes the unnecessary conditional statements and ensures that the zero star author count is correctly displayed.

Fixes #87