### PR TITLE
fix: hide counts in title metadata

### DIFF
--- a/authors.qmd
+++ b/authors.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Authors ({{< var authors >}})"
+pagetitle: "Authors"
 repo-actions: false
 listing:
   id: listing-authors

--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Extensions ({{< var extensions >}})"
+pagetitle: "Extensions"
 repo-actions: false
 listing:
   id: listing-extensions


### PR DESCRIPTION
This pull request ensures that the title metadata and page titles are correctly displayed without the counts in browsers.