### PR TITLE
feat: Add Quarto extension installer

### DIFF
--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -1,0 +1,4 @@
+out
+node_modules
+.vscode-test
+*.vsix

--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .vscode-test
 *.vsix
+debug

--- a/vscode/.vscode/launch.json
+++ b/vscode/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "${defaultBuildTask}"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/test/**/*.js"
+      ],
+      "preLaunchTask": "${defaultBuildTask}"
+    }
+  ]
+}

--- a/vscode/.vscode/launch.json
+++ b/vscode/.vscode/launch.json
@@ -9,7 +9,8 @@
       "type": "extensionHost",
       "request": "launch",
       "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "${workspaceFolder}/debug"
       ],
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"

--- a/vscode/.vscode/launch.json
+++ b/vscode/.vscode/launch.json
@@ -15,7 +15,7 @@
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"
       ],
-      "preLaunchTask": "${defaultBuildTask}"
+      "preLaunchTask": "Debug"
     },
     {
       "name": "Extension Tests",

--- a/vscode/.vscode/tasks.json
+++ b/vscode/.vscode/tasks.json
@@ -1,0 +1,20 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "watch",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/vscode/.vscode/tasks.json
+++ b/vscode/.vscode/tasks.json
@@ -4,12 +4,6 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-      "label": "Debug",
-      "type": "shell",
-      "command": "mkdir -p ${workspaceFolder}/debug; rm -rf ${workspaceFolder}/debug/_extensions; exit 0;",
-      "problemMatcher": []
-    },
-		{
 			"type": "npm",
 			"script": "watch",
 			"problemMatcher": "$tsc-watch",
@@ -21,6 +15,12 @@
 				"kind": "build",
 				"isDefault": true
 			}
-		}
+		},
+		{
+      "label": "Debug",
+      "type": "shell",
+      "command": "mkdir -p ${workspaceFolder}/debug; rm -rf ${workspaceFolder}/debug/_extensions; exit 0;",
+      "problemMatcher": []
+    }
 	]
 }

--- a/vscode/.vscode/tasks.json
+++ b/vscode/.vscode/tasks.json
@@ -4,6 +4,12 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
+      "label": "Debug",
+      "type": "shell",
+      "command": "mkdir -p ${workspaceFolder}/debug; rm -rf ${workspaceFolder}/debug/_extensions; exit 0;",
+      "problemMatcher": []
+    },
+		{
 			"type": "npm",
 			"script": "watch",
 			"problemMatcher": "$tsc-watch",

--- a/vscode/.vscode/tasks.json
+++ b/vscode/.vscode/tasks.json
@@ -19,7 +19,7 @@
 		{
       "label": "Debug",
       "type": "shell",
-      "command": "mkdir -p ${workspaceFolder}/debug; rm -rf ${workspaceFolder}/debug/_extensions; exit 0;",
+      "command": "npm run compile; mkdir -p ${workspaceFolder}/debug; rm -rf ${workspaceFolder}/debug/_extensions; exit 0;",
       "problemMatcher": []
     }
 	]

--- a/vscode/LICENSE
+++ b/vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Mickaël Canouil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,0 +1,70 @@
+# Quarto Extension Installer
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## Overview
+
+The **Quarto Extension Installer** is a Visual Studio Code extension that allows you to easily install Quarto extensions directly from the [Quarto Extensions Repository](https://github.com/mcanouil/quarto-extensions).
+This extension provides a user-friendly interface to browse, select, and install Quarto extensions, enhancing your Quarto development experience.
+
+## Features
+
+- **Browse Extensions**: View a list of available Quarto extensions.
+- **Install Extensions**: Install selected Quarto extensions with a single click.
+- **Show Output**: View detailed logs of the installation process.
+
+## Requirements
+
+- **Check Internet Connection**: Ensure you have an active internet connection before installing extensions.
+- **Check Quarto Installation**: Verify that Quarto is installed and available in your system's PATH.
+
+## Usage
+
+1. Open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on macOS).
+2. Type `Quarto: Install Extension(s)` and select it.
+3. Browse the list of available extensions.
+4. Select the extensions you want to install.
+5. Answer the prompts to confirm the installation.
+
+## Commands
+
+- `Quarto: Install Extension(s)`: Opens the extension installer interface.
+- `Quarto: Show Quarto Extension Installer Output`: Displays the output log for the extension installer.
+
+## Development
+
+### Installation
+
+1. Clone the repository:
+    ```sh
+    git clone https://github.com/mcanouil/quarto-extensions/tree/main/vscode
+    ```
+2. Open the project in Visual Studio Code.
+3. Install the dependencies:
+    ```sh
+    npm install
+    ```
+4. Compile the extension:
+    ```sh
+    npm run compile
+    ```
+5. Launch the extension:
+    - Press `F5` to open a new VS Code window with the extension loaded.
+
+### Running the Extension
+
+- Open this project in Visual Studio Code.
+- Press `F5` to open a new VS Code window with the extension loaded.
+
+### Running Tests
+
+- Open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on macOS).
+- Type `Tasks: Run Test Task` and select it.
+
+## Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request on the [GitHub repository](https://github.com/mcanouil/quarto-extensions).
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,7 +1,5 @@
 # Quarto Extension Installer
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-
 ## Overview
 
 The **Quarto Extension Installer** is a Visual Studio Code extension that allows you to easily install Quarto extensions directly from the [Quarto Extensions Repository](https://github.com/mcanouil/quarto-extensions).

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.8.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.6.tgz",
-      "integrity": "sha512-tosuJYKrIqjQIlVCM4PEGxOmyg3FCPa/fViuJChnGeEIhjA46oy8FMVoF9su1/v8PNs2a8Q0iFNyOx0uOF91nw==",
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "quarto-extension-installer",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "quarto-extension-installer",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^22.8.6",
+        "@types/vscode": "^1.75.0",
+        "typescript": "^5.6.2"
+      },
+      "engines": {
+        "vscode": "^1.75.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.6.tgz",
+      "integrity": "sha512-tosuJYKrIqjQIlVCM4PEGxOmyg3FCPa/fViuJChnGeEIhjA46oy8FMVoF9su1/v8PNs2a8Q0iFNyOx0uOF91nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.8"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.95.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.95.0.tgz",
+      "integrity": "sha512-0LBD8TEiNbet3NvWsmn59zLzOFu/txSlGxnv5yAFHCrhG9WvAnR3IvfHzMOs2aeWqgvNjq9pO99IUw8d3n+unw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "quarto-extension-installer",
       "version": "0.0.1",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.8.6",
         "@types/vscode": "^1.75.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -29,8 +29,12 @@
   "contributes": {
     "commands": [
       {
-        "command": "quartoExtensionInstaller.installExtension",
-        "title": "Quarto: Install Extension(s) from mcanouil/quarto-extensions"
+        "command": "quartoExtensions.installExtension",
+        "title": "Quarto: Install Extension(s)"
+      },
+      {
+        "command": "quartoExtensions.showOutput",
+        "title": "Quarto: Show Quarto Extension Installer Output"
       }
     ]
   },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,22 @@
   "displayName": "Quarto Extension Installer",
   "description": "Install Quarto extensions from https://github.com/mcanouil/quarto-extensions",
   "version": "0.0.1",
-  "publisher": "your-name",
+  "publisher": "Mickaël Canouil",
+  "license": "MIT",
+  "private": true,
+  "keywords": [
+    "markdown",
+    "pandoc",
+    "quarto"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mcanouil/quarto-extensions/tree/main/vscode"
+  },
+  "homepage": "https://github.com/mcanouil/quarto-extensions/tree/main/vscode",
+  "bugs": {
+    "url": "https://github.com/mcanouil/quarto-extensions/issues"
+  },
   "engines": {
     "vscode": "^1.75.0"
   },
@@ -12,7 +27,7 @@
     "commands": [
       {
         "command": "quartoExtensionInstaller.installExtension",
-        "title": "Quarto: Install Quarto Extension (mcanouil/quarto-extensions)"
+        "title": "Quarto: Install Extension(s) from mcanouil/quarto-extensions"
       }
     ]
   },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "quarto-extension-installer",
+  "displayName": "Quarto Extension Installer",
+  "description": "Install Quarto extensions from https://github.com/mcanouil/quarto-extensions",
+  "version": "0.0.1",
+  "publisher": "your-name",
+  "engines": {
+    "vscode": "^1.75.0"
+  },
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "quartoExtensionInstaller.installExtension",
+        "title": "Quarto: Install Quarto Extension (mcanouil/quarto-extensions)"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "lint": "eslint",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/node": "^22.8.6",
+    "@types/vscode": "^1.75.0",
+    "typescript": "^5.6.2"
+  }
+}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "quarto-extension-installer",
   "displayName": "Quarto Extension Installer",
   "description": "Install Quarto extensions from https://github.com/mcanouil/quarto-extensions",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "publisher": "mcanouil",
   "author": {
     "name": "Mickaël CANOUIL"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,10 @@
   "displayName": "Quarto Extension Installer",
   "description": "Install Quarto extensions from https://github.com/mcanouil/quarto-extensions",
   "version": "0.0.1",
-  "publisher": "Mickaël Canouil",
+  "publisher": "mcanouil",
+  "author": {
+    "name": "Mickaël CANOUIL"
+  },
   "license": "MIT",
   "private": true,
   "keywords": [

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -76,6 +76,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
 
+  // context.globalState.update(RECENTLY_INSTALLED_QEXT_KEY, []);
   context.subscriptions.push(disposable);
 }
 

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -30,7 +30,7 @@ export function activate(context: vscode.ExtensionContext) {
       if (selectedExtension) {
         const terminal = vscode.window.createTerminal("Quarto");
         terminal.show();
-        terminal.sendText(`quarto add ${selectedExtension}`);
+        terminal.sendText(`quarto add ${selectedExtension} --no-prompt`);
       }
     }
   );

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -60,7 +60,8 @@ export function activate(context: vscode.ExtensionContext) {
       ) {
         const terminal = vscode.window.createTerminal("Quarto");
         terminal.show();
-        terminal.sendText(`quarto add ${selectedExtension.label} --no-prompt`);
+        selectedExtension.label.match(/\(([^)]+)\)$/)
+        terminal.sendText(`quarto add ${selectedExtension.label.match(/\(([^)]+)\)$/)?.[1] ?? ''} --no-prompt`);
 
         // Update recently installed extensions
         recentlyInstalled = [
@@ -110,7 +111,7 @@ function formatExtensionLabel(ext: string): string {
     .split(" ")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(" ");
-  return formattedRepo;
+  return `${formattedRepo} (${ext})`;
 }
 
 export function deactivate() {}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -44,6 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
       quickPick.items = groupedExtensions;
       quickPick.placeholder = "Select Quarto extensions to install";
       quickPick.canSelectMany = true;
+      quickPick.matchOnDescription = true;
       quickPick.onDidTriggerItemButton((e) => {
         const url = e.item.url;
         if (url) {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -13,6 +13,12 @@ interface ExtensionQuickPickItem extends vscode.QuickPickItem {
 }
 
 export function activate(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('quartoExtension.showOutput', () => {
+      quartoExtensionLog.show();
+    })
+  );
+
   let disposable = vscode.commands.registerCommand(
     "quartoExtensionInstaller.installExtension",
     async () => {
@@ -193,12 +199,12 @@ async function installExtensions(
   vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
-      title: "Installing selected extension(s)",
+      title: "Installing selected extension(s) ([details](command:quartoExtension.showOutput))",
       cancellable: true,
     },
     async (progress, token) => {
       token.onCancellationRequested(() => {
-        const message = "Operation cancelled by the user.";
+        const message = "Operation cancelled by the user ([details](command:quartoExtension.showOutput)).";
         quartoExtensionLog.appendLine(message);
         vscode.window.showInformationMessage(message);
       });
@@ -229,7 +235,7 @@ async function installExtensions(
       }
 
       if (installedExtensions.length > 0) {
-        quartoExtensionLog.appendLine(`\n\nSuccesfully installed extensions:`);
+        quartoExtensionLog.appendLine(`\n\nSuccessfully installed extensions:`);
         installedExtensions.forEach((ext) => {
           quartoExtensionLog.appendLine(` - ${ext}`);
         });
@@ -240,12 +246,12 @@ async function installExtensions(
         failedExtensions.forEach((ext) => {
           quartoExtensionLog.appendLine(` - ${ext}`);
         });
-        const message = "The following extensions were not installed, try installing theme manually with \`quarto add <extension>\`:"
-        vscode.window.showErrorMessage(`${message} ${failedExtensions.join(", ")}`);
+        const message = "The following extensions were not installed, try installing them manually with `quarto add <extension>`:";
+        vscode.window.showErrorMessage(`${message} ${failedExtensions.join(", ")}. See [details](command:quartoExtension.showOutput).`);
       } else {
         const message = `All selected extensions (${installedCount}) were installed successfully.`;
         quartoExtensionLog.appendLine(message);
-        vscode.window.showInformationMessage(message);
+        vscode.window.showInformationMessage(`${message} See [details](command:quartoExtension.showOutput).`);
       }
     }
   );

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as https from "https";
 import { IncomingMessage } from "http";
 
-const RECENTLY_INSTALLED_KEY = "recentlyInstalledExtensions";
+const RECENTLY_INSTALLED_QEXT_KEY = "recentlyInstalledExtensions";
 
 export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand(
@@ -12,7 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
         "https://raw.githubusercontent.com/mcanouil/quarto-extensions/main/extensions/quarto-extensions.csv";
       let extensionsList: string[] = [];
       let recentlyInstalled: string[] = context.globalState.get(
-        RECENTLY_INSTALLED_KEY,
+        RECENTLY_INSTALLED_QEXT_KEY,
         []
       );
 
@@ -67,7 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
           selectedExtension.label,
           ...recentlyInstalled.filter((ext) => ext !== selectedExtension.label),
         ].slice(0, 5);
-        context.globalState.update(RECENTLY_INSTALLED_KEY, recentlyInstalled);
+        context.globalState.update(RECENTLY_INSTALLED_QEXT_KEY, recentlyInstalled);
       }
     }
   );

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -33,7 +33,8 @@ export function activate(context: vscode.ExtensionContext) {
       );
 
       try {
-        const data = await fetchCSVFromURL(csvUrl);
+        // const data = await fetchCSVFromURL(csvUrl);
+        const data = "mcanouil/quarto-animate\nmcanouil/quarto-elevator\nmcanouil/quarto-github\nmcanouil/quarto-highlight-text"
         extensionsList = data.split("\n").filter((line) => line.trim() !== "");
       } catch (error) {
         const message = `Error fetching "quarto-extensions.csv" from ${csvUrl}`;
@@ -186,6 +187,7 @@ async function installExtensions(
         vscode.window.showInformationMessage(message);
 			});
 
+      const installedExtensions: string[] = [];
       const failedExtensions: string[] = [];
       const totalExtensions = mutableSelectedExtensions.length;
       let installedCount = 0;
@@ -194,24 +196,15 @@ async function installExtensions(
         if (selectedExtension.description === undefined) {
           continue;
         }
-
-        let success: boolean;
-
-        try {
-          await installQuartoExtension(selectedExtension.description);
-          success = true;
-        } catch {
-          success = false;
-        }
+        const success = await installQuartoExtension(selectedExtension.description);;
         if (success) {
-          if (selectedExtension.description !== undefined) {
-            recentlyInstalled = [
-              selectedExtension.description,
-              ...recentlyInstalled.filter(
-                (ext) => ext !== selectedExtension.description
-              ),
-            ].slice(0, 5);
-          }
+          recentlyInstalled = [
+            selectedExtension.description,
+            ...recentlyInstalled.filter(
+              (ext) => ext !== selectedExtension.description
+            ),
+          ].slice(0, 5);
+          installedExtensions.push(selectedExtension.description);
         } else {
           failedExtensions.push(selectedExtension.description);
         }
@@ -231,12 +224,10 @@ async function installExtensions(
         const message = `All selected extensions (${installedCount}) were installed successfully.`;
         quartoExtensionLog.appendLine(message);
         vscode.window.showInformationMessage(message);
-        // const terminal = vscode.window.terminals.find(
-        //   (t) => t.name === "quarto-extensions"
-        // );
-        // if (terminal) {
-        //   terminal.dispose();
-        // }
+        quartoExtensionLog.appendLine(`\n\nInstalled Extensions:`);
+        installedExtensions.forEach((ext) => {
+          quartoExtensionLog.appendLine(` - ${ext}`);
+        });
       }
     }
   );

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -11,7 +11,10 @@ export function activate(context: vscode.ExtensionContext) {
       const csvUrl =
         "https://raw.githubusercontent.com/mcanouil/quarto-extensions/main/extensions/quarto-extensions.csv";
       let extensionsList: string[] = [];
-      let recentlyInstalled: string[] = context.globalState.get(RECENTLY_INSTALLED_KEY, []);
+      let recentlyInstalled: string[] = context.globalState.get(
+        RECENTLY_INSTALLED_KEY,
+        []
+      );
 
       try {
         const data = await fetchCSVFromURL(csvUrl);
@@ -24,29 +27,46 @@ export function activate(context: vscode.ExtensionContext) {
       }
 
       const groupedExtensions = [
-        { label: "Recently Installed", kind: vscode.QuickPickItemKind.Separator },
-        ...recentlyInstalled.map((ext) => ({
-          label: formatExtensionLabel(ext),
-          description: getGitHubLink(ext),
-        })),
+        {
+          label: "Recently Installed",
+          kind: vscode.QuickPickItemKind.Separator,
+        },
+        ...recentlyInstalled
+          .map((ext) => ({
+            label: formatExtensionLabel(ext),
+            description: getGitHubLink(ext),
+          }))
+          .sort((a, b) => a.label.localeCompare(b.label)),
         { label: "All Extensions", kind: vscode.QuickPickItemKind.Separator },
-        ...extensionsList.map((ext) => ({
-          label: formatExtensionLabel(ext),
-          description: getGitHubLink(ext),
-        })),
+        ...extensionsList
+          .map((ext) => ({
+            label: formatExtensionLabel(ext),
+            description: getGitHubLink(ext),
+          }))
+          .sort((a, b) => a.label.localeCompare(b.label)),
       ];
 
-      const selectedExtension = await vscode.window.showQuickPick(groupedExtensions, {
-        placeHolder: "Select a Quarto extension to install",
-      });
+      const selectedExtension = await vscode.window.showQuickPick(
+        groupedExtensions,
+        {
+          placeHolder: "Select a Quarto extension to install",
+        }
+      );
 
-      if (selectedExtension && selectedExtension.label !== "All Extensions" && selectedExtension.label !== "Recently Installed") {
+      if (
+        selectedExtension &&
+        selectedExtension.label !== "All Extensions" &&
+        selectedExtension.label !== "Recently Installed"
+      ) {
         const terminal = vscode.window.createTerminal("Quarto");
         terminal.show();
         terminal.sendText(`quarto add ${selectedExtension.label} --no-prompt`);
 
         // Update recently installed extensions
-        recentlyInstalled = [selectedExtension.label, ...recentlyInstalled.filter(ext => ext !== selectedExtension.label)].slice(0, 5);
+        recentlyInstalled = [
+          selectedExtension.label,
+          ...recentlyInstalled.filter((ext) => ext !== selectedExtension.label),
+        ].slice(0, 5);
         context.globalState.update(RECENTLY_INSTALLED_KEY, recentlyInstalled);
       }
     }
@@ -57,17 +77,19 @@ export function activate(context: vscode.ExtensionContext) {
 
 async function fetchCSVFromURL(url: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    https.get(url, (res: IncomingMessage) => {
-      let data = "";
-      res.on("data", (chunk) => {
-        data += chunk;
+    https
+      .get(url, (res: IncomingMessage) => {
+        let data = "";
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+        res.on("end", () => {
+          resolve(data);
+        });
+      })
+      .on("error", (err) => {
+        reject(err);
       });
-      res.on("end", () => {
-        resolve(data);
-      });
-    }).on("error", (err) => {
-      reject(err);
-    });
   });
 }
 

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -58,10 +58,35 @@ export function activate(context: vscode.ExtensionContext) {
           selectedExtension.label !== "All Extensions" &&
           selectedExtension.label !== "Recently Installed"
         ) {
-          const terminal = vscode.window.createTerminal("Quarto");
+          const trustAuthors = await vscode.window.showQuickPick(
+            ["Yes", "No"],
+            {
+              placeHolder: "Do you trust the authors of this extension?"
+            }
+          );
+  
+          if (trustAuthors !== "Yes") {
+            vscode.window.showInformationMessage("Operation cancelled by the user.");
+            return;
+          }
+
+          const installWorkspace = await vscode.window.showQuickPick(
+            ["Yes", "No"],
+            {
+              placeHolder: "Install extension in the current workspace?"
+            }
+          );
+
+          if (installWorkspace !== "Yes") {
+            vscode.window.showInformationMessage("Operation cancelled by the user.");
+            return;
+          }
+
+          vscode.window.showInformationMessage("Installing selected extension(s) ...");
+          const terminal = vscode.window.createTerminal("Quarto-Extensions");
           terminal.show();
-          const match = selectedExtension.label.match(/\(([^)]+)\)$/);
-          terminal.sendText(`quarto add ${match?.[1] ?? ""} --no-prompt`);
+          const rawExtension = selectedExtension.label.match(/\(([^)]+)\)$/);
+          terminal.sendText(`quarto add ${rawExtension?.[1] ?? ""} --no-prompt`);
 
           // Update recently installed extensions
           recentlyInstalled = [
@@ -82,7 +107,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  // context.globalState.update(RECENTLY_INSTALLED_QEXT_KEY, []);
+  context.globalState.update(RECENTLY_INSTALLED_QEXT_KEY, []);
   context.subscriptions.push(disposable);
 }
 

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -33,8 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
       );
 
       try {
-        // const data = await fetchCSVFromURL(csvUrl);
-        const data = "mcanouil/quarto-animate\nmcanouil/quarto-elevator\nmcanouil/quarto-github\nmcanouil/quarto-highlight-text"
+        const data = await fetchCSVFromURL(csvUrl);
         extensionsList = data.split("\n").filter((line) => line.trim() !== "");
       } catch (error) {
         const message = `Error fetching "quarto-extensions.csv" from ${csvUrl}`;
@@ -196,7 +195,7 @@ async function installExtensions(
         if (selectedExtension.description === undefined) {
           continue;
         }
-        const success = await installQuartoExtension(selectedExtension.description);;
+        const success = await installQuartoExtension(selectedExtension.description);
         if (success) {
           recentlyInstalled = [
             selectedExtension.description,

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -20,7 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   let disposable = vscode.commands.registerCommand(
-    "quartoExtensionInstaller.installExtension",
+    "quartoExtension.installExtension",
     async () => {
       const isConnected = await checkInternetConnection();
       if (!isConnected) {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -57,32 +57,42 @@ export function activate(context: vscode.ExtensionContext) {
           const trustAuthors = await vscode.window.showQuickPick(
             ["Yes", "No"],
             {
-              placeHolder: "Do you trust the authors of the selected extension(s)?"
+              placeHolder:
+                "Do you trust the authors of the selected extension(s)?",
             }
           );
-  
+
           if (trustAuthors !== "Yes") {
-            vscode.window.showInformationMessage("Operation cancelled by the user.");
+            vscode.window.showInformationMessage(
+              "Operation cancelled by the user."
+            );
             return;
           }
 
           const installWorkspace = await vscode.window.showQuickPick(
             ["Yes", "No"],
             {
-              placeHolder: "Install the selected extension(s) in the current workspace?"
+              placeHolder:
+                "Install the selected extension(s) in the current workspace?",
             }
           );
 
           if (installWorkspace !== "Yes") {
-            vscode.window.showInformationMessage("Operation cancelled by the user.");
+            vscode.window.showInformationMessage(
+              "Operation cancelled by the user."
+            );
             return;
           }
 
-          vscode.window.showInformationMessage("Installing selected extension(s) ...");
+          vscode.window.showInformationMessage(
+            "Installing selected extension(s) ..."
+          );
           const terminal = vscode.window.createTerminal("Quarto-Extensions");
           terminal.show();
           selectedExtensions.forEach((selectedExtension) => {
-            terminal.sendText(`quarto add ${selectedExtension.description} --no-prompt`);
+            terminal.sendText(
+              `quarto add ${selectedExtension.description} --no-prompt`
+            );
             // Update recently installed extensions
             if (selectedExtension.description !== undefined) {
               recentlyInstalled = [

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -35,31 +35,9 @@ export function activate(context: vscode.ExtensionContext) {
           label: "Recently Installed",
           kind: vscode.QuickPickItemKind.Separator,
         },
-        ...recentlyInstalled
-          .map((ext) => ({
-            label: formatExtensionLabel(ext),
-            buttons: [
-              {
-                iconPath: new vscode.ThemeIcon("info"),
-                tooltip: "Open GitHub Repository",
-              },
-            ],
-            url: getGitHubLink(ext),
-          }))
-          .sort((a, b) => a.label.localeCompare(b.label)),
+        ...createExtensionItems(recentlyInstalled),
         { label: "All Extensions", kind: vscode.QuickPickItemKind.Separator },
-        ...extensionsList
-          .map((ext) => ({
-            label: formatExtensionLabel(ext),
-            buttons: [
-              {
-                iconPath: new vscode.ThemeIcon("info"),
-                tooltip: "Open GitHub Repository",
-              },
-            ],
-            url: getGitHubLink(ext),
-          }))
-          .sort((a, b) => a.label.localeCompare(b.label)),
+        ...createExtensionItems(extensionsList),
       ];
 
       const quickPick = vscode.window.createQuickPick<ExtensionQuickPickItem>();
@@ -83,12 +61,14 @@ export function activate(context: vscode.ExtensionContext) {
           const terminal = vscode.window.createTerminal("Quarto");
           terminal.show();
           const match = selectedExtension.label.match(/\(([^)]+)\)$/);
-          terminal.sendText(`quarto add ${match?.[1] ?? ''} --no-prompt`);
+          terminal.sendText(`quarto add ${match?.[1] ?? ""} --no-prompt`);
 
           // Update recently installed extensions
           recentlyInstalled = [
             selectedExtension.label,
-            ...recentlyInstalled.filter((ext) => ext !== selectedExtension.label),
+            ...recentlyInstalled.filter(
+              (ext) => ext !== selectedExtension.label
+            ),
           ].slice(0, 5);
           context.globalState.update(
             RECENTLY_INSTALLED_QEXT_KEY,
@@ -139,6 +119,21 @@ function formatExtensionLabel(ext: string): string {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(" ");
   return `${formattedRepo} (${ext})`;
+}
+
+function createExtensionItems(extensions: string[]): ExtensionQuickPickItem[] {
+  return extensions
+    .map((ext) => ({
+      label: formatExtensionLabel(ext),
+      buttons: [
+        {
+          iconPath: new vscode.ThemeIcon("github"),
+          tooltip: "Open GitHub Repository",
+        },
+      ],
+      url: getGitHubLink(ext),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
 }
 
 export function deactivate() {}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -6,6 +6,7 @@ const RECENTLY_INSTALLED_QEXT_KEY = "recentlyInstalledExtensions";
 
 interface ExtensionQuickPickItem extends vscode.QuickPickItem {
   url?: string;
+  prettyLabel?: string;
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -43,7 +44,6 @@ export function activate(context: vscode.ExtensionContext) {
       const quickPick = vscode.window.createQuickPick<ExtensionQuickPickItem>();
       quickPick.items = groupedExtensions;
       quickPick.placeholder = "Select a Quarto extension to install";
-
       quickPick.onDidTriggerItemButton((e) => {
         const url = e.item.url;
         if (url) {
@@ -85,8 +85,7 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.window.showInformationMessage("Installing selected extension(s) ...");
           const terminal = vscode.window.createTerminal("Quarto-Extensions");
           terminal.show();
-          const rawExtension = selectedExtension.label.match(/\(([^)]+)\)$/);
-          terminal.sendText(`quarto add ${rawExtension?.[1] ?? ""} --no-prompt`);
+          terminal.sendText(`quarto add ${selectedExtension.label} --no-prompt`);
 
           // Update recently installed extensions
           recentlyInstalled = [
@@ -107,7 +106,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  context.globalState.update(RECENTLY_INSTALLED_QEXT_KEY, []);
+  // context.globalState.update(RECENTLY_INSTALLED_QEXT_KEY, []);
   context.subscriptions.push(disposable);
 }
 
@@ -149,7 +148,8 @@ function formatExtensionLabel(ext: string): string {
 function createExtensionItems(extensions: string[]): ExtensionQuickPickItem[] {
   return extensions
     .map((ext) => ({
-      label: formatExtensionLabel(ext),
+      label: ext,
+      prettyLabel: formatExtensionLabel(ext),
       buttons: [
         {
           iconPath: new vscode.ThemeIcon("github"),
@@ -158,7 +158,7 @@ function createExtensionItems(extensions: string[]): ExtensionQuickPickItem[] {
       ],
       url: getGitHubLink(ext),
     }))
-    .sort((a, b) => a.label.localeCompare(b.label));
+    .sort((a, b) => a.prettyLabel.localeCompare(b.prettyLabel));
 }
 
 export function deactivate() {}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -67,7 +67,10 @@ export function activate(context: vscode.ExtensionContext) {
           selectedExtension.label,
           ...recentlyInstalled.filter((ext) => ext !== selectedExtension.label),
         ].slice(0, 5);
-        context.globalState.update(RECENTLY_INSTALLED_QEXT_KEY, recentlyInstalled);
+        context.globalState.update(
+          RECENTLY_INSTALLED_QEXT_KEY,
+          recentlyInstalled
+        );
       }
     }
   );

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -34,14 +34,14 @@ export function activate(context: vscode.ExtensionContext) {
         ...recentlyInstalled
           .map((ext) => ({
             label: formatExtensionLabel(ext),
-            description: getGitHubLink(ext),
+            detail: getGitHubLink(ext),
           }))
           .sort((a, b) => a.label.localeCompare(b.label)),
         { label: "All Extensions", kind: vscode.QuickPickItemKind.Separator },
         ...extensionsList
           .map((ext) => ({
             label: formatExtensionLabel(ext),
-            description: getGitHubLink(ext),
+            detail: getGitHubLink(ext),
           }))
           .sort((a, b) => a.label.localeCompare(b.label)),
       ];

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -81,18 +81,6 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(disposable);
 }
 
-async function checkQuartoVersion(): Promise<boolean> {
-  return new Promise((resolve) => {
-    exec("quarto --version", (error, stdout, stderr) => {
-      if (error || stderr) {
-        resolve(false);
-      } else {
-        resolve(stdout.trim().length > 0);
-      }
-    });
-  });
-}
-
 async function fetchCSVFromURL(url: string): Promise<string> {
   return new Promise((resolve, reject) => {
     https
@@ -111,37 +99,16 @@ async function fetchCSVFromURL(url: string): Promise<string> {
   });
 }
 
-function getGitHubLink(extension: string): string {
-  const [owner, repo] = extension.split("/").slice(0, 2);
-  return `https://github.com/${owner}/${repo}`;
-}
-
-function formatExtensionLabel(ext: string): string {
-  const parts = ext.split("/");
-  const repo = parts[1];
-  let formattedRepo = repo.replace(/[-_]/g, " ");
-  formattedRepo = formattedRepo.replace(/quarto/gi, "").trim();
-  formattedRepo = formattedRepo
-    .split(" ")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-    .join(" ");
-  return formattedRepo;
-}
-
-function createExtensionItems(extensions: string[]): ExtensionQuickPickItem[] {
-  return extensions
-    .map((ext) => ({
-      label: formatExtensionLabel(ext),
-      description: ext,
-      buttons: [
-        {
-          iconPath: new vscode.ThemeIcon("github"),
-          tooltip: "Open GitHub Repository",
-        },
-      ],
-      url: getGitHubLink(ext),
-    }))
-    .sort((a, b) => a.label.localeCompare(b.label));
+async function checkQuartoVersion(): Promise<boolean> {
+  return new Promise((resolve) => {
+    exec("quarto --version", (error, stdout, stderr) => {
+      if (error || stderr) {
+        resolve(false);
+      } else {
+        resolve(stdout.trim().length > 0);
+      }
+    });
+  });
 }
 
 async function installQuartoExtension(extension: string): Promise<boolean> {
@@ -223,6 +190,39 @@ async function installExtensions(
       )}`
     );
   }
+}
+
+function getGitHubLink(extension: string): string {
+  const [owner, repo] = extension.split("/").slice(0, 2);
+  return `https://github.com/${owner}/${repo}`;
+}
+
+function formatExtensionLabel(ext: string): string {
+  const parts = ext.split("/");
+  const repo = parts[1];
+  let formattedRepo = repo.replace(/[-_]/g, " ");
+  formattedRepo = formattedRepo.replace(/quarto/gi, "").trim();
+  formattedRepo = formattedRepo
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+  return formattedRepo;
+}
+
+function createExtensionItems(extensions: string[]): ExtensionQuickPickItem[] {
+  return extensions
+    .map((ext) => ({
+      label: formatExtensionLabel(ext),
+      description: ext,
+      buttons: [
+        {
+          iconPath: new vscode.ThemeIcon("github"),
+          tooltip: "Open GitHub Repository",
+        },
+      ],
+      url: getGitHubLink(ext),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
 }
 
 export function deactivate() {}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,0 +1,66 @@
+import * as vscode from "vscode";
+import * as https from "https";
+import { IncomingMessage } from "http";
+
+export function activate(context: vscode.ExtensionContext) {
+  let disposable = vscode.commands.registerCommand(
+    "quartoExtensionInstaller.installExtension",
+    async () => {
+      const csvUrl =
+        "https://raw.githubusercontent.com/mcanouil/quarto-extensions/main/extensions/quarto-extensions.csv";
+      let extensionsList: string[] = [];
+
+      try {
+        const data = await fetchCSVFromURL(csvUrl);
+        extensionsList = data.split("\n").filter((line) => line.trim() !== "");
+      } catch (error) {
+        vscode.window.showErrorMessage(
+          'Error fetching "quarto-extensions.csv" from https:///github.com/mcanouil/quarto-extensions'
+        );
+        return;
+      }
+
+      const selectedExtension = await vscode.window.showQuickPick(
+        extensionsList,
+        {
+          placeHolder: "Select a Quarto extension to install",
+        }
+      );
+
+      if (selectedExtension) {
+        const terminal = vscode.window.createTerminal("Quarto");
+        terminal.show();
+        terminal.sendText(`quarto add ${selectedExtension}`);
+      }
+    }
+  );
+
+  context.subscriptions.push(disposable);
+}
+
+async function fetchCSVFromURL(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res: IncomingMessage) => {
+        const data: Uint8Array[] = [];
+
+        res.on("data", (chunk: Uint8Array) => {
+          data.push(chunk);
+        });
+
+        res.on("end", () => {
+          const buffer = Buffer.concat(data);
+          resolve(buffer.toString("utf8"));
+        });
+
+        res.on("error", (err: Error) => {
+          reject(err);
+        });
+      })
+      .on("error", (err: Error) => {
+        reject(err);
+      });
+  });
+}
+
+export function deactivate() {}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -118,7 +118,7 @@ async function installQuartoExtension(extension: string): Promise<boolean> {
   if (!terminal) {
     terminal = vscode.window.createTerminal("quarto-extensions");
   }
-  terminal.sendText(`exit $(quarto add ${extension} --no-prompt);`, true);
+  terminal.sendText(`quarto add ${extension} --no-prompt`, true);
 
   return new Promise((resolve) => {
     const disposable = vscode.window.onDidCloseTerminal((closedTerminal) => {
@@ -171,9 +171,13 @@ async function installExtensions(
     {
       location: vscode.ProgressLocation.Notification,
       title: "Installing selected extension(s)",
-      cancellable: false,
+      cancellable: true,
     },
-    async (progress) => {
+    async (progress, token) => {
+      token.onCancellationRequested(() => {
+				console.log("Operation cancelled by the user.");
+			});
+
       const failedExtensions: string[] = [];
       const totalExtensions = mutableSelectedExtensions.length;
       let installedCount = 0;

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -7,7 +7,6 @@ const RECENTLY_INSTALLED_QEXT_KEY = "recentlyInstalledExtensions";
 
 const quartoExtensionLog = vscode.window.createOutputChannel('Quarto Extensions');
 
-
 interface ExtensionQuickPickItem extends vscode.QuickPickItem {
   url?: string;
 }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -111,21 +111,6 @@ async function checkQuartoVersion(): Promise<boolean> {
   });
 }
 
-// async function installQuartoExtension2(extension: string): Promise<boolean> {
-//   return new Promise((resolve) => {
-//     exec(`quarto add ${extension} --no-prompt`, (error, stdout, stderr) => {
-//       if (error) {
-//         console.error(`exec error: ${error}`);
-//         resolve(false);
-//         return;
-//       }
-//       console.log(`stdout: ${stdout}`);
-//       console.error(`stderr: ${stderr}`);
-//       resolve(true);
-//     });
-//   });
-// }
-
 async function installQuartoExtension(extension: string): Promise<boolean> {
   let terminal = vscode.window.terminals.find(
     (t) => t.name === "quarto-extensions"
@@ -133,7 +118,6 @@ async function installQuartoExtension(extension: string): Promise<boolean> {
   if (!terminal) {
     terminal = vscode.window.createTerminal("quarto-extensions");
   }
-  // terminal.show();
   terminal.sendText(`exit $(quarto add ${extension} --no-prompt);`, true);
 
   return new Promise((resolve) => {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -6,7 +6,6 @@ const RECENTLY_INSTALLED_QEXT_KEY = "recentlyInstalledExtensions";
 
 interface ExtensionQuickPickItem extends vscode.QuickPickItem {
   url?: string;
-  prettyLabel?: string;
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -85,13 +84,13 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.window.showInformationMessage("Installing selected extension(s) ...");
           const terminal = vscode.window.createTerminal("Quarto-Extensions");
           terminal.show();
-          terminal.sendText(`quarto add ${selectedExtension.label} --no-prompt`);
+          terminal.sendText(`quarto add ${selectedExtension.label.replace(/^.*-- /, '')} --no-prompt`);
 
           // Update recently installed extensions
           recentlyInstalled = [
-            selectedExtension.label,
+            selectedExtension.label.replace(/^.*-- /, ''),
             ...recentlyInstalled.filter(
-              (ext) => ext !== selectedExtension.label
+              (ext) => ext !== selectedExtension.label.replace(/^.*-- /, '')
             ),
           ].slice(0, 5);
           context.globalState.update(
@@ -142,14 +141,13 @@ function formatExtensionLabel(ext: string): string {
     .split(" ")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(" ");
-  return `${formattedRepo} (${ext})`;
+  return `${formattedRepo} -- ${ext}`;
 }
 
 function createExtensionItems(extensions: string[]): ExtensionQuickPickItem[] {
   return extensions
     .map((ext) => ({
-      label: ext,
-      prettyLabel: formatExtensionLabel(ext),
+      label: formatExtensionLabel(ext),
       buttons: [
         {
           iconPath: new vscode.ThemeIcon("github"),
@@ -158,7 +156,7 @@ function createExtensionItems(extensions: string[]): ExtensionQuickPickItem[] {
       ],
       url: getGitHubLink(ext),
     }))
-    .sort((a, b) => a.prettyLabel.localeCompare(b.prettyLabel));
+    .sort((a, b) => a.label.localeCompare(b.label));
 }
 
 export function deactivate() {}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -55,7 +55,8 @@ export function activate(context: vscode.ExtensionContext) {
         if (
           selectedExtension &&
           selectedExtension.label !== "All Extensions" &&
-          selectedExtension.label !== "Recently Installed"
+          selectedExtension.label !== "Recently Installed" &&
+          selectedExtension.description !== undefined
         ) {
           const trustAuthors = await vscode.window.showQuickPick(
             ["Yes", "No"],
@@ -84,13 +85,13 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.window.showInformationMessage("Installing selected extension(s) ...");
           const terminal = vscode.window.createTerminal("Quarto-Extensions");
           terminal.show();
-          terminal.sendText(`quarto add ${selectedExtension.label.replace(/^.*-- /, '')} --no-prompt`);
+          terminal.sendText(`quarto add ${selectedExtension.description} --no-prompt`);
 
           // Update recently installed extensions
           recentlyInstalled = [
-            selectedExtension.label.replace(/^.*-- /, ''),
+            selectedExtension.description,
             ...recentlyInstalled.filter(
-              (ext) => ext !== selectedExtension.label.replace(/^.*-- /, '')
+              (ext) => ext !== selectedExtension.description
             ),
           ].slice(0, 5);
           context.globalState.update(
@@ -105,7 +106,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  // context.globalState.update(RECENTLY_INSTALLED_QEXT_KEY, []);
+  context.globalState.update(RECENTLY_INSTALLED_QEXT_KEY, []);
   context.subscriptions.push(disposable);
 }
 
@@ -141,13 +142,14 @@ function formatExtensionLabel(ext: string): string {
     .split(" ")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(" ");
-  return `${formattedRepo} -- ${ext}`;
+  return formattedRepo;
 }
 
 function createExtensionItems(extensions: string[]): ExtensionQuickPickItem[] {
   return extensions
     .map((ext) => ({
       label: formatExtensionLabel(ext),
+      description: ext,
       buttons: [
         {
           iconPath: new vscode.ThemeIcon("github"),

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "out",
+    "target": "es2020",
+    "lib": [
+      "es2020"
+    ],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true
+  },
+  "exclude": [
+    "node_modules",
+    ".vscode-test"
+  ]
+}


### PR DESCRIPTION
Introduce a VSCode extension that allows users to install Quarto extensions listed in mcanouil/quarto-extensions. 