### PR TITLE
chore: add quarto-ext/typst extensions and few others

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -142,7 +142,9 @@ pagiraud/fullframegraphics
 pagiraud/speakernotes
 pandoc-ext/abstract-section
 pandoc-ext/diagram
+pandoc-ext/list-table
 pandoc-ext/multibib
+pandoc-ext/run-lua
 pandoc-ext/section-bibliographies
 parmsam/quarto-excalidraw
 parmsam/quarto-flashcards
@@ -171,6 +173,12 @@ quarto-ext/latex-environment
 quarto-ext/lightbox
 quarto-ext/pointer
 quarto-ext/shinylive
+quarto-ext/typst-templates/ams
+quarto-ext/typst-templates/dept-news
+quarto-ext/typst-templates/fiction
+quarto-ext/typst-templates/ieee
+quarto-ext/typst-templates/letter
+quarto-ext/typst-templates/poster
 quarto-journals/acm
 quarto-journals/acs
 quarto-journals/agu
@@ -184,7 +192,11 @@ r-wasm/quarto-live
 rchaput/acronyms
 restlessronin/gfm-strip-disallowed
 reuning/codeFocus
+roaldarbol/pdf-to-image
 schochastics/academicons
+schochastics/classic-cv
+schochastics/modern-cv
+schochastics/modern2-cv
 schochastics/quarto-blackboard-theme
 schochastics/quarto-nutshell
 schochastics/quarto-sketchy-html


### PR DESCRIPTION
Introduce new quarto extensions, including typst templates and additional pandoc extensions.