### PR TITLE
revert: addition of quarto-ext/typst-templates

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -173,12 +173,6 @@ quarto-ext/latex-environment
 quarto-ext/lightbox
 quarto-ext/pointer
 quarto-ext/shinylive
-quarto-ext/typst-templates/ams
-quarto-ext/typst-templates/dept-news
-quarto-ext/typst-templates/fiction
-quarto-ext/typst-templates/ieee
-quarto-ext/typst-templates/letter
-quarto-ext/typst-templates/poster
 quarto-journals/acm
 quarto-journals/acs
 quarto-journals/agu


### PR DESCRIPTION
Remove the recently added typst templates from the quarto extensions list as they all share the same metadata thus they can't all be actually listed.