### PR TITLE
fix: categories in card functionality

### DIFF
--- a/assets/ejs/extensions.ejs
+++ b/assets/ejs/extensions.ejs
@@ -25,7 +25,7 @@ let removeLeadingZeros = function (str) {
 :::: {.listing-categories}
 ```{=html}
 <% for (const category of item.categories) { %>
-<div class="listing-category" onclick="window.quartoListingCategory('<%=category%>'); return false;"><%= category %></div>
+<div class="listing-category" onclick="window.quartoListingCategory('<%= utils.b64encode(category) %>'); return false;"><%= category %></div>
 <% } %>
 ```
 :::


### PR DESCRIPTION
The changes ensure that categories in the card correctly encode the category names, resolving the issue where categories did not function as intended. Fixes #136