### PR TITLE
feat: use Quarto Wizard for installation options

### DIFF
--- a/assets/ejs/extension-install-modal.ejs
+++ b/assets/ejs/extension-install-modal.ejs
@@ -1,0 +1,59 @@
+```{=html}
+<button type="button" class="btn btn-secondary" style="text-align: center;" data-bs-toggle="modal" data-bs-target="#installModal">Install</button>
+<div class="modal fade" id="installModal" tabindex="-1" aria-labelledby="installModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="installModalLabel">Install Options</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <ul class="list-group list-group-flush"">
+          <li class="list-group-item list-group-item-action">
+```
+
+:::: {.fw-bold style="text-align: left;"}
+{{< iconify octicon:terminal >}} Manually
+:::
+
+```{.sh filename='Terminal' style="font-size: 0.8em; text-align: left;"}
+quarto add <%= item.usage %>
+```
+
+```{=html}
+          </li>
+          <li class="list-group-item list-group-item-action">
+```
+
+:::: {.fw-bold style="text-align: left;"}
+{{< iconify octicon:cloud-download >}} Using Quarto Wizard
+:::
+
+```{=html}
+            <div class="btn-group" role="group" aria-label="Quarto Wizard extension installer options">
+              <button
+                type="button"
+                class="btn btn-outline-secondary"
+                onclick="window.location.href='vscode://mcanouil.quarto-wizard/install?repo=<%= item.usage %>'"
+                data-bs-toggle="tooltip" title="Install <%= item.usage %> in Visual Studio Code using Quarto Wizard extension."
+              >Visual Studio Code</button>
+              <button
+                type="button"
+                class="btn btn-outline-secondary"
+                onclick="window.location.href='positron://mcanouil.quarto-wizard/install?repo=<%= item.usage %>'"
+                data-bs-toggle="tooltip" title="Install <%= item.usage %> in Positron using Quarto Wizard extension."
+              >Positron</button>
+              <button
+                type="button"
+                class="btn btn-outline-secondary"
+                onclick="window.location.href='vscodium://mcanouil.quarto-wizard/install?repo=<%= item.usage %>'"
+                data-bs-toggle="tooltip" title="Install <%= item.usage %> in VSCodium using Quarto Wizard extension."
+              >VSCodium</button>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+```

--- a/assets/ejs/extensions.ejs
+++ b/assets/ejs/extensions.ejs
@@ -30,8 +30,13 @@ let removeLeadingZeros = function (str) {
 ```
 :::
 
-:::: {.card-text .listing-description}
+:::: {.card-text}
+:::: {.listing-description}
 <%= item.description %>
+:::
+
+<% partial("extension-install-modal.ejs", { item }) %>
+
 :::
 
 :::: {.card-attribution .card-text-small .justify}

--- a/assets/scripts/make-yaml.sh
+++ b/assets/scripts/make-yaml.sh
@@ -30,9 +30,6 @@ sort -f extensions/quarto-extensions.csv | while IFS=, read -r entry; do
       repo_release="[${repo_release#v}]($repo_release_url)"
       repo_updated=$(echo "${repo_info}" | jq -r ".latestRelease.publishedAt")
     fi
-    yaml_usage_header="\n    \n    \`\`\`{.sh filename='Terminal'}\n    quarto add "
-    yaml_usage_footer="\n    \`\`\`\n"
-    yaml_usage="${yaml_usage_header}${yaml_usage_body}${yaml_usage_footer}"
     repo_license=$(echo "${repo_info}" | jq -r ".licenseInfo.name")
     if [[ "${repo_license}" = "null" ]]; then
       repo_license="No license specified"
@@ -76,7 +73,8 @@ sort -f extensions/quarto-extensions.csv | while IFS=, read -r entry; do
       " license: \"${repo_license}\"\n" \
       " stars: \"$(printf "%05d\n" ${repo_stars})\"\n" \
       " version: \"${repo_release}\"\n" \
-      " description: |\n    ${repo_description}\n${yaml_usage}\n" \
+      " description: |\n    ${repo_description}\n" \
+      " usage: ${yaml_usage_body}\n" \
       > "${meta}"
     if [[ "${repo_owner}" == "${previous_repo_owner}" ]]; then
       count_extensions=$((count_extensions+1))

--- a/assets/stylesheets/extensions.scss
+++ b/assets/stylesheets/extensions.scss
@@ -9,7 +9,6 @@
   margin: 8px;
   padding: 10px 15px;
   position: relative;
-  z-index: 1;
   overflow: hidden;
   min-height: 265px;
   transition: 0.7s;


### PR DESCRIPTION
Implement the Quarto Wizard installation options in the extension installation modal. This change enhances the user experience by providing a streamlined method for installing extensions via the Quarto Wizard.

Fixes #138