### PR TITLE
chore: Adds 6 extensions

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -232,3 +232,9 @@ kapsner/audio-slideshow
 schochastics/quarto-url-peek
 peter-gy/quarto-gradio
 hchulkim/econ-paper-template
+christopherkenny/annual-reviews
+christopherkenny/cambridge-medium
+christopherkenny/wordcount
+christopherkenny/spellcheck
+christopherkenny/tufte
+christopherkenny/ctk-article


### PR DESCRIPTION
Resolves #146, I've added some templates and extensions that are ready for general use.

## Extension Submission :atom:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

## Description

I have confirmed that each of these have both a description and a topic.

- `annual-reviews`: A template for the Annual Reviews journal
- `cambridge-medium`: A template for many of the Cambridge journals, primarily social sciences
- `wordcount`: An extension to count words in documents
- `spellcheck`: An extension to spell check documents using hunspell
- `tufte`: A Tufte-style document built in Typst + Quarto
- `ctk-article`: A clean pre-print template built in Typst + Quarto
