### PR TITLE
fix: modal display issue for multiple values

### DIFF
--- a/assets/ejs/extension-install-modal.ejs
+++ b/assets/ejs/extension-install-modal.ejs
@@ -1,6 +1,6 @@
 ```{=html}
-<button type="button" class="btn btn-secondary" style="text-align: center;" data-bs-toggle="modal" data-bs-target="#installModal">Install</button>
-<div class="modal fade" id="installModal" tabindex="-1" aria-labelledby="installModalLabel" aria-hidden="true">
+<button type="button" class="btn btn-secondary" style="text-align: center;" data-bs-toggle="modal" data-bs-target="#installModal-<%= id %>">Install</button>
+<div class="modal fade" id="installModal-<%= id %>" tabindex="-1" aria-labelledby="installModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
@@ -8,7 +8,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <ul class="list-group list-group-flush"">
+        <ul class="list-group list-group-flush">
           <li class="list-group-item list-group-item-action">
 ```
 
@@ -17,7 +17,7 @@
 :::
 
 ```{.sh filename='Terminal' style="font-size: 0.8em; text-align: left;"}
-quarto add <%= item.usage %>
+quarto add <%= usage %>
 ```
 
 ```{=html}
@@ -34,20 +34,20 @@ quarto add <%= item.usage %>
               <button
                 type="button"
                 class="btn btn-outline-secondary"
-                onclick="window.location.href='vscode://mcanouil.quarto-wizard/install?repo=<%= item.usage %>'"
-                data-bs-toggle="tooltip" title="Install <%= item.usage %> in Visual Studio Code using Quarto Wizard extension."
+                onclick="window.location.href='vscode://mcanouil.quarto-wizard/install?repo=<%= usage %>'"
+                data-bs-toggle="tooltip" title="Install <%= usage %> in Visual Studio Code using Quarto Wizard extension."
               >Visual Studio Code</button>
               <button
                 type="button"
                 class="btn btn-outline-secondary"
-                onclick="window.location.href='positron://mcanouil.quarto-wizard/install?repo=<%= item.usage %>'"
-                data-bs-toggle="tooltip" title="Install <%= item.usage %> in Positron using Quarto Wizard extension."
+                onclick="window.location.href='positron://mcanouil.quarto-wizard/install?repo=<%= usage %>'"
+                data-bs-toggle="tooltip" title="Install <%= usage %> in Positron using Quarto Wizard extension."
               >Positron</button>
               <button
                 type="button"
                 class="btn btn-outline-secondary"
-                onclick="window.location.href='vscodium://mcanouil.quarto-wizard/install?repo=<%= item.usage %>'"
-                data-bs-toggle="tooltip" title="Install <%= item.usage %> in VSCodium using Quarto Wizard extension."
+                onclick="window.location.href='vscodium://mcanouil.quarto-wizard/install?repo=<%= usage %>'"
+                data-bs-toggle="tooltip" title="Install <%= usage %> in VSCodium using Quarto Wizard extension."
               >VSCodium</button>
             </div>
           </li>

--- a/assets/ejs/extension-use-modal.ejs
+++ b/assets/ejs/extension-use-modal.ejs
@@ -1,6 +1,6 @@
 ```{=html}
-<button type="button" class="btn btn-secondary" style="text-align: center;" data-bs-toggle="modal" data-bs-target="#useModal">Use Template</button>
-<div class="modal fade" id="useModal" tabindex="-1" aria-labelledby="useModalLabel" aria-hidden="true">
+<button type="button" class="btn btn-secondary" style="text-align: center;" data-bs-toggle="modal" data-bs-target="#useModal-<%= id %>">Use Template</button>
+<div class="modal fade" id="useModal-<%= id %>" tabindex="-1" aria-labelledby="useModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
@@ -8,7 +8,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <ul class="list-group list-group-flush"">
+        <ul class="list-group list-group-flush">
           <li class="list-group-item list-group-item-action">
 ```
 
@@ -17,7 +17,7 @@
 :::
 
 ```{.sh filename='Terminal' style="font-size: 0.8em; text-align: left;"}
-quarto use template <%= item.usage %>
+quarto use template <%= usage %>
 ```
 
 ```{=html}
@@ -34,20 +34,20 @@ quarto use template <%= item.usage %>
               <button
                 type="button"
                 class="btn btn-outline-secondary"
-                onclick="window.location.href='vscode://mcanouil.quarto-wizard/use?repo=<%= item.usage %>'"
-                data-bs-toggle="tooltip" title="Use <%= item.usage %> template in Visual Studio Code using Quarto Wizard extension."
+                onclick="window.location.href='vscode://mcanouil.quarto-wizard/use?repo=<%= usage %>'"
+                data-bs-toggle="tooltip" title="Use <%= usage %> template in Visual Studio Code using Quarto Wizard extension."
               >Visual Studio Code</button>
               <button
                 type="button"
                 class="btn btn-outline-secondary"
-                onclick="window.location.href='positron://mcanouil.quarto-wizard/use?repo=<%= item.usage %>'"
-                data-bs-toggle="tooltip" title="Use <%= item.usage %> template in Positron using Quarto Wizard extension."
+                onclick="window.location.href='positron://mcanouil.quarto-wizard/use?repo=<%= usage %>'"
+                data-bs-toggle="tooltip" title="Use <%= usage %> template in Positron using Quarto Wizard extension."
               >Positron</button>
               <button
                 type="button"
                 class="btn btn-outline-secondary"
-                onclick="window.location.href='vscodium://mcanouil.quarto-wizard/use?repo=<%= item.usage %>'"
-                data-bs-toggle="tooltip" title="Use <%= item.usage %> template in VSCodium using Quarto Wizard extension."
+                onclick="window.location.href='vscodium://mcanouil.quarto-wizard/use?repo=<%= usage %>'"
+                data-bs-toggle="tooltip" title="Use <%= usage %> template in VSCodium using Quarto Wizard extension."
               >VSCodium</button>
             </div>
           </li>

--- a/assets/ejs/extensions.ejs
+++ b/assets/ejs/extensions.ejs
@@ -39,11 +39,15 @@
 <%= item.description %>
 :::
 
-<% if (item.template === true) { %>
-<% partial("extension-install-modal.ejs", { item }) %><% partial("extension-use-modal.ejs", { item }) %>
-<% } else { %>
-<% partial("extension-install-modal.ejs", { item }) %>
-<% } %>
+
+<%
+const usage = item.usage;
+const id = utils.b64encode(usage);
+partial("extension-install-modal.ejs", { id, usage });
+if (item.template === true) {
+partial("extension-use-modal.ejs", { id, usage });
+}
+%>
 
 :::
 


### PR DESCRIPTION
Modals previously displayed only the first value on the page. Update ensures each modal correctly references its respective value, allowing for accurate display and interaction.

Fixes #156