### PR TITLE
chore: add release requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ To add your extension to this list, please submit a pull request to this reposit
 > - The extension is not already listed.
 > - Your GitHub repository contains a **Description**.
 > - Your GitHub repository contains **Topics**.
+> - Your GitHub repository contains a **Release** with **Tag**.
 > - Avoid special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.

--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -238,3 +238,4 @@ wearetechnative/texnative
 wjschne/apaquarto
 zachcp/quarto-swissbiopics
 sun123zxy/quarto-callouty-theorem
+cl-roberts/code-appendix


### PR DESCRIPTION
I suggest adding a line to the `quarto-extensions` readme to inform contributors that they should have a release/tag on their extensions. 