### PR TITLE
chore: update Iconify extension to version 3.0.1

### DIFF
--- a/_extensions/mcanouil/iconify/_extension.yml
+++ b/_extensions/mcanouil/iconify/_extension.yml
@@ -1,8 +1,8 @@
 title: Iconify
 author: Mickaël Canouil
-version: 3.0.0
+version: 3.0.1
 quarto-required: ">=1.5.57"
 contributes:
   shortcodes:
     - iconify.lua
-source: mcanouil/quarto-iconify@3.0.0
+source: mcanouil/quarto-iconify@3.0.1

--- a/_extensions/mcanouil/iconify/iconify.lua
+++ b/_extensions/mcanouil/iconify/iconify.lua
@@ -22,7 +22,12 @@
 # SOFTWARE.
 ]]
 
+--- @type function
 local stringify = pandoc.utils.stringify
+
+--- Flag to track if deprecation warning has been shown
+--- @type boolean
+local deprecation_warning_shown = false
 
 --- Ensure Iconify HTML dependencies are included.
 --- @return nil
@@ -41,6 +46,27 @@ local function is_empty(s)
   return s == nil or s == ''
 end
 
+--- Check for deprecated top-level iconify configuration and emit warning.
+--- @param meta table<string, any> Document metadata table
+--- @param key string The configuration key being accessed
+--- @return string|nil The value from deprecated config, or nil if not found
+local function check_deprecated_config(meta, key)
+  if not is_empty(meta['iconify']) and not is_empty(meta['iconify'][key]) then
+    if not deprecation_warning_shown then
+      quarto.log.warning(
+        'Top-level "iconify" configuration is deprecated. ' ..
+        'Please use:\n' ..
+        'extensions:\n' ..
+        '  iconify:\n' ..
+        '    ' .. key .. ': value'
+      )
+      deprecation_warning_shown = true
+    end
+    return stringify(meta['iconify'][key])
+  end
+  return nil
+end
+
 --- Validate and convert size keyword to CSS font-size.
 --- @param size string|nil
 --- @return string
@@ -48,33 +74,34 @@ local function is_valid_size(size)
   if is_empty(size) then
     return ''
   end
+  --- @type table<string, string>
   local size_table = {
-    ["tiny"]         = "0.5em",
-    ["scriptsize"]   = "0.7em",
-    ["footnotesize"] = "0.8em",
-    ["small"]        = "0.9em",
-    ["normalsize"]   = "1em",
-    ["large"]        = "1.2em",
-    ["Large"]        = "1.5em",
-    ["LARGE"]        = "1.75em",
-    ["huge"]         = "2em",
-    ["Huge"]         = "2.5em",
-    ["1x"]           = "1em",
-    ["2x"]           = "2em",
-    ["3x"]           = "3em",
-    ["4x"]           = "4em",
-    ["5x"]           = "5em",
-    ["6x"]           = "6em",
-    ["7x"]           = "7em",
-    ["8x"]           = "8em",
-    ["9x"]           = "9em",
-    ["10x"]          = "10em",
-    ["2xs"]          = "0.625em",
-    ["xs"]           = "0.75em",
-    ["sm"]           = "0.875em",
-    ["lg"]           = "1.25em",
-    ["xl"]           = "1.5em",
-    ["2xl"]          = "2em"
+    ['tiny']         = '0.5em',
+    ['scriptsize']   = '0.7em',
+    ['footnotesize'] = '0.8em',
+    ['small']        = '0.9em',
+    ['normalsize']   = '1em',
+    ['large']        = '1.2em',
+    ['Large']        = '1.5em',
+    ['LARGE']        = '1.75em',
+    ['huge']         = '2em',
+    ['Huge']         = '2.5em',
+    ['1x']           = '1em',
+    ['2x']           = '2em',
+    ['3x']           = '3em',
+    ['4x']           = '4em',
+    ['5x']           = '5em',
+    ['6x']           = '6em',
+    ['7x']           = '7em',
+    ['8x']           = '8em',
+    ['9x']           = '9em',
+    ['10x']          = '10em',
+    ['2xs']          = '0.625em',
+    ['xs']           = '0.75em',
+    ['sm']           = '0.875em',
+    ['lg']           = '1.25em',
+    ['xl']           = '1.5em',
+    ['2xl']          = '2em'
   }
   for key, value in pairs(size_table) do
     if key == size then
@@ -85,34 +112,60 @@ local function is_valid_size(size)
 end
 
 --- Get iconify option from arguments or metadata.
---- @param x string
---- @param arg table
---- @param meta table
---- @return string
+--- @param x string The option name to retrieve
+--- @param arg table<string, any> Arguments table containing options
+--- @param meta table<string, any> Document metadata table
+--- @return string The option value as a string
 local function get_iconify_options(x, arg, meta)
+  --- @type string
   local arg_value = stringify(arg[x])
-  if is_empty(meta['iconify']) or not is_empty(arg_value) then
+  
+  -- Return argument value if provided
+  if not is_empty(arg_value) then
     return arg_value
   end
-  if not is_empty(meta['iconify'][x]) then
-    return stringify(meta['iconify'][x])
+  
+  -- Check new nested structure: extensions.iconify.x
+  if not is_empty(meta['extensions']) and 
+     not is_empty(meta['extensions']['iconify']) and 
+     not is_empty(meta['extensions']['iconify'][x]) then
+    return stringify(meta['extensions']['iconify'][x])
   end
+  
+  -- Check deprecated top-level structure: iconify.x (with warning)
+  local deprecated_value = check_deprecated_config(meta, x)
+  if deprecated_value then
+    return deprecated_value
+  end
+  
   return arg_value
 end
 
 --- Render an Iconify icon as a Pandoc RawInline for HTML output.
---- @param args table Icon arguments (icon set and name).
---- @param kwargs table Key-value options for the icon.
---- @param meta table Document metadata.
---- @return pandoc.Inline|pandoc.Null
+--- @param args table<integer, any> Icon arguments (icon set and name)
+--- @param kwargs table<string, any> Key-value options for the icon
+--- @param meta table<string, any> Document metadata
+--- @return any Pandoc RawInline for HTML or Pandoc Null for other formats
 function iconify(args, kwargs, meta)
   -- detect html (excluding epub which won't handle fa)
-  if quarto.doc.is_format("html:js") then
+  if quarto.doc.is_format('html:js') then
     ensure_html_deps()
+    --- @type string
     local icon = stringify(args[1])
+    --- @type string
     local set = 'octicon'
-    if not is_empty(meta['iconify']) and not is_empty(meta['iconify']['set']) then
-      set = stringify(meta['iconify']['set'])
+    
+    -- Check new nested structure for default set
+    if not is_empty(meta['extensions']) and 
+       not is_empty(meta['extensions']['iconify']) and 
+       not is_empty(meta['extensions']['iconify']['set']) then
+      set = stringify(meta['extensions']['iconify']['set'])
+    else
+      -- Check deprecated top-level structure for default set (with warning)
+      local deprecated_set = check_deprecated_config(meta, 'set')
+      if deprecated_set then
+        set = deprecated_set
+      end
     end
 
     if #args > 1 and string.find(stringify(args[2]), ':') then
@@ -123,19 +176,23 @@ function iconify(args, kwargs, meta)
       icon = stringify(args[2])
     end
 
-    if string.find(icon, ":") then
-      set = string.sub(icon, 1, string.find(icon, ":") - 1)
-      icon = string.sub(icon, string.find(icon, ":") + 1)
+    if string.find(icon, ':') then
+      set = string.sub(icon, 1, string.find(icon, ':') - 1)
+      icon = string.sub(icon, string.find(icon, ':') + 1)
     elseif #args > 1 then
       set = icon
       icon = stringify(args[2])
     end
 
+    --- @type string
     local attributes = ' icon="' .. set .. ':' .. icon .. '"'
+    --- @type string
     local default_label = 'Icon ' .. icon .. ' from ' .. set .. ' Iconify.design set.'
 
-    local size = is_valid_size(get_iconify_options("size", kwargs, meta))
-    local style = get_iconify_options("style", kwargs, meta)
+    --- @type string
+    local size = is_valid_size(get_iconify_options('size', kwargs, meta))
+    --- @type string
+    local style = get_iconify_options('style', kwargs, meta)
 
     if is_empty(style) and not is_empty(size) then
       attributes = attributes .. ' style="' .. size .. '"'
@@ -145,14 +202,16 @@ function iconify(args, kwargs, meta)
       attributes = attributes .. ' style="' .. style .. '"'
     end
 
-    local aria_label = stringify(kwargs["label"])
+    --- @type string
+    local aria_label = stringify(kwargs['label'])
     if is_empty(aria_label) then
       aria_label =  ' aria-label="' .. default_label .. '"'
     else
       aria_label =  ' aria-label="' .. aria_label .. '"'
     end
 
-    local title = stringify(kwargs["title"])
+    --- @type string
+    local title = stringify(kwargs['title'])
     if is_empty(title) then
       title =  ' title="' .. default_label .. '"'
     else
@@ -161,29 +220,36 @@ function iconify(args, kwargs, meta)
 
     attributes = attributes .. aria_label .. title
 
-    local width = get_iconify_options("width", kwargs, meta)
+    --- @type string
+    local width = get_iconify_options('width', kwargs, meta)
     if not is_empty(width) and is_empty(size) then
       attributes = attributes .. ' width="' .. width .. '"'
     end
-    local height = get_iconify_options("height", kwargs, meta)
+    --- @type string
+    local height = get_iconify_options('height', kwargs, meta)
     if not is_empty(height) and is_empty(size)  then
       attributes = attributes .. ' height="' .. height .. '"'
     end
-    local flip = get_iconify_options("flip", kwargs, meta)
+    --- @type string
+    local flip = get_iconify_options('flip', kwargs, meta)
     if not is_empty(flip) then
       attributes = attributes .. ' flip="' .. flip.. '"'
     end
-    local rotate = get_iconify_options("rotate", kwargs, meta)
+    --- @type string
+    local rotate = get_iconify_options('rotate', kwargs, meta)
     if not is_empty(rotate) then
       attributes = attributes .. ' rotate="' .. rotate .. '"'
     end
 
-    local inline = get_iconify_options("inline", kwargs, meta)
-    if is_empty(inline) or inline ~= "false" then
+    --- @type string
+    local inline = get_iconify_options('inline', kwargs, meta)
+    if is_empty(inline) or inline ~= 'false' then
       attributes = ' inline ' .. attributes
     end
 
-    local mode = get_iconify_options("mode", kwargs, meta)
+    --- @type string
+    local mode = get_iconify_options('mode', kwargs, meta)
+    --- @type table<string, boolean>
     local valid_modes = { svg = true, style = true, bg = true, mask = true }
     if not is_empty(mode) and valid_modes[mode] then
       attributes = attributes .. ' mode="' .. mode .. '"'
@@ -198,6 +264,37 @@ function iconify(args, kwargs, meta)
   end
 end
 
+--- Render Quarto icon using the iconify function with preset styling.
+--- @param args table<integer, any> Icon arguments (ignored as we're using a preset icon)
+--- @param kwargs table<string, any>|nil Key-value options that might override default styling
+--- @param meta table<string, any> Document metadata
+--- @return any Pandoc RawInline for HTML or Pandoc Null for other formats
+function iconify_quarto(args, kwargs, meta)
+  --- @type table<integer, string>
+  local quarto_args = { 'simple-icons:quarto' }
+  --- @type table<string, any>
+  local quarto_kwargs = kwargs or {}
+  quarto_kwargs['label'] = 'Quarto icon'
+  quarto_kwargs['title'] = 'Quarto icon'
+  --- @type string
+  local quarto_colour = 'color:#74aadb;'
+  
+  if not is_empty(quarto_kwargs['style']) then
+    --- @type string
+    local style = stringify(quarto_kwargs['style'])
+    if string.match(style, 'color:[^;]+;') then
+      quarto_kwargs['style'] = string.gsub(style, 'color:[^;]+;', quarto_colour)
+    else
+      quarto_kwargs['style'] = quarto_colour .. style
+    end
+  else
+    quarto_kwargs['style'] = quarto_colour
+  end
+  return iconify(quarto_args, quarto_kwargs, meta)
+end
+
+--- @type table<string, function>
 return {
-  ["iconify"] = iconify
+  ['iconify'] = iconify,
+  ['quarto'] = iconify_quarto
 }


### PR DESCRIPTION
Upgrade the Iconify extension to the latest version, which includes enhancements and deprecation warnings for configuration changes.