### PR TITLE
fix: remove page title from extensions listing page

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,4 @@
 ---
-pagetitle: "Extensions"
 repo-actions: false
 image: "assets/media/quarto-extensions.png"
 date-format: iso


### PR DESCRIPTION
Eliminate the page title from the extensions listing.