### PR TITLE
ci: use existing social card PNG if available

### DIFF
--- a/.github/workflows/quarto-wizard.yml
+++ b/.github/workflows/quarto-wizard.yml
@@ -168,14 +168,10 @@ jobs:
                   git rm --cached "${output_file}" 2>/dev/null || true
                   rm -f "${output_file}"
                 fi
-                if [[ -f "${output_file}" ]]; then
-                  echo "${output_file}"
-                else
-                  echo "${placeholder_file}"
-                fi
-              else
-                echo "${output_file}"
               fi
+            fi
+            if [[ -f "${output_file}" ]]; then
+              echo "${output_file}"
             else
               echo "${placeholder_file}"
             fi


### PR DESCRIPTION
Ensure the card uses the existing social card PNG even if it is not up to date. Fixes #204