### PR TITLE
chore: add mergemeta to quarto extensions list

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -254,6 +254,7 @@ thinkr-open/quakr
 thinkr-open/quarto-detective
 ttalvlatt/quarto-docx-horizontal-rule
 ute/custom-numbered-blocks
+ute/mergemeta
 ute/search-replace
 wearetechnative/texnative
 wjschne/apaquarto


### PR DESCRIPTION
This pull request adds a new extension.

* Added the `ute/mergemeta` extension to the Quarto extensions list in `extensions/quarto-extensions.csv`.

cc. @ute