### PR TITLE
Update quarto-extensions.csv

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -264,3 +264,4 @@ kbodwin/flourish
 fredguth/bibentry
 christopherkenny/projector
 MateusMolina/custom-amsthm-environments
+simonreif/notes-block


### PR DESCRIPTION
Added note-block for LaTeX Templates

<!--- Please provide a general summary of your changes in the title above -->

## Extension Submission

I confirm that I have checked that:

- [x ] I have checked that the extension GitHub repository has a description.
- [ x] I have checked that the extension GitHub repository has topics.

- [ x] The extension is not already listed.
- [x ] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [ x] The GitHub repository contains **Topics**.
- [ x] The GitHub repository contains a **Release** with **Tag**.
- [x ] The GitHub repository has `example.qmd` or `template.qmd` file.
- [ x] The GitHub repository has only one extension or a set of extensions.

## Description

This extension makes it easy to add table and figure notes to Quarto output. At the moment this works only for PDF outputs from LaTeX.
