### PR TITLE
fix: use description field for search in grid view

### DIFF
--- a/assets/ejs/_grid.ejs
+++ b/assets/ejs/_grid.ejs
@@ -79,7 +79,7 @@ if (diffDays === 1) {
           </button>
         </p>
         
-        <p class="card-text flex-grow-1">
+        <p class="card-text flex-grow-1 extension-description">
           <%- item.description %>
         </p>
         


### PR DESCRIPTION
Ensure the description field is included in the search functionality when in grid view. This change addresses the issue where descriptions were previously ignored during searches, enhancing the overall search experience.

Fixes #223