### PR TITLE
fix: description is not used for search in grid view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.luarc.json
 /.quarto/
+**/*.quarto_ipynb
 /_site/
 /site_libs/
 /extensions/**/

--- a/assets/ejs/_grid.ejs
+++ b/assets/ejs/_grid.ejs
@@ -58,7 +58,7 @@ if (diffDays === 1) {
       
       <!-- Card Body -->
       <div class="card-body d-flex flex-column">
-        <h6 class="card-title d-flex align-items-center justify-content-between no-anchor">
+        <h6 class="card-title d-flex align-items-center justify-content-between no-anchor extension-title">
           <span>
             <a href="<%= item['github-url'] %>" target="_blank">
               <%= item.title %>

--- a/assets/scripts/quarto-extensions-listing.html
+++ b/assets/scripts/quarto-extensions-listing.html
@@ -130,8 +130,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     extensions.forEach(ext => {
       try {
-        const titleEl = ext.querySelector('.extension-title, .card-title');
-        const descEl = ext.querySelector('.extension-description, .card-text');
+        const titleEl = ext.querySelector('.extension-title');
+        const descEl = ext.querySelector('.extension-description');
         
         // Defensive checks for missing elements
         const title = titleEl ? titleEl.textContent.toLowerCase() : '';


### PR DESCRIPTION
Update the search functionality to include the "description" field properly when in grid view, by fixing the query selector.

Fixes #223