### PR TITLE
refactor: implement shared status banner function

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -60,9 +60,9 @@ Add one of the following topics to your GitHub repository to display a status ba
 
 - [{{< iconify bi:exclamation-triangle-fill >}} superseded]{.alert .alert-warning .mb-0 .rounded-0 .text-center .py-1 role="alert"} - For extensions that have been replaced by a newer version or alternative.
 - [{{< iconify bi:exclamation-triangle-fill >}} deprecated]{.alert .alert-warning .mb-0 .rounded-0 .text-center .py-1 role="alert"} - For extensions that are outdated and should not be used in new projects.
-- [{{< iconify bi:exclamation-triangle-fill >}} archived]{.alert .alert-secondary .mb-0 .rounded-0 .text-center .py-1 role="alert"} - For extensions that are no longer actively maintained.
-- [{{< iconify bi:exclamation-triangle-fill >}} experimental]{.alert .alert-info .mb-0 .rounded-0 .text-center .py-1 role="alert"} - For extensions that are in early development or testing phase.
-- [{{< iconify bi:exclamation-triangle-fill >}} stable]{.alert .alert-success .mb-0 .rounded-0 .text-center .py-1 role="alert"} - For extensions that are production-ready and actively maintained.
+- [{{< iconify bi:archive-fill >}} archived]{.alert .alert-secondary .mb-0 .rounded-0 .text-center .py-1 role="alert"} - For extensions that are no longer actively maintained.
+- [{{< iconify bi:flask >}} experimental]{.alert .alert-info .mb-0 .rounded-0 .text-center .py-1 role="alert"} - For extensions that are in early development or testing phase.
+- [{{< iconify bi:check-circle-fill >}} stable]{.alert .alert-success .mb-0 .rounded-0 .text-center .py-1 role="alert"} - For extensions that are production-ready and actively maintained.
 
 If multiple status topics are present, the priority order is: `superseded` > `deprecated` > `archived` > `experimental` > `stable`.
 

--- a/assets/ejs/_grid.ejs
+++ b/assets/ejs/_grid.ejs
@@ -36,20 +36,8 @@ if (diffDays === 1) {
   relativeTime = years === 1 ? '1 year ago' : `${years} years ago`;
 }
 
-// Check for status keywords (priority: superseded > deprecated > archived > experimental > stable)
-const categories = item.categories.map(c => c.toLowerCase());
-let statusBanner = null;
-if (categories.includes('superseded')) {
-  statusBanner = { type: 'superseded', text: 'Superseded', class: 'warning' };
-} else if (categories.includes('deprecated')) {
-  statusBanner = { type: 'deprecated', text: 'Deprecated', class: 'warning' };
-} else if (categories.includes('archived')) {
-  statusBanner = { type: 'archived', text: 'Archived', class: 'secondary' };
-} else if (categories.includes('experimental')) {
-  statusBanner = { type: 'experimental', text: 'Experimental', class: 'info' };
-} else if (categories.includes('stable')) {
-  statusBanner = { type: 'stable', text: 'Stable', class: 'success' };
-}
+// Get status banner using shared function
+const statusBanner = getStatusBanner(item.categories);
 %>
 
 ```{=html}
@@ -74,7 +62,10 @@ if (categories.includes('superseded')) {
       <% if (statusBanner) { %>
       <!-- Status Banner -->
       <div class="alert alert-<%= statusBanner.class %> status-banner mb-0 rounded-0 text-center py-1" role="alert">
-        <i class="bi bi-exclamation-triangle-fill"></i> <strong><%= statusBanner.text %></strong>
+        <% if (statusBanner.icon) { %>
+        <i class="bi <%= statusBanner.icon %>"></i>
+        <% } %>
+        <strong><%= statusBanner.text %></strong>
       </div>
       <% } %>
 

--- a/assets/ejs/_list.ejs
+++ b/assets/ejs/_list.ejs
@@ -36,20 +36,8 @@ if (diffDays === 1) {
   relativeTime = years === 1 ? '1 year ago' : `${years} years ago`;
 }
 
-// Check for status keywords (priority: superseded > deprecated > archived > experimental > stable)
-const categories = item.categories.map(c => c.toLowerCase());
-let statusBanner = null;
-if (categories.includes('superseded')) {
-  statusBanner = { type: 'superseded', text: 'Superseded', class: 'warning' };
-} else if (categories.includes('deprecated')) {
-  statusBanner = { type: 'deprecated', text: 'Deprecated', class: 'warning' };
-} else if (categories.includes('archived')) {
-  statusBanner = { type: 'archived', text: 'Archived', class: 'secondary' };
-} else if (categories.includes('experimental')) {
-  statusBanner = { type: 'experimental', text: 'Experimental', class: 'info' };
-} else if (categories.includes('stable')) {
-  statusBanner = { type: 'stable', text: 'Stable', class: 'success' };
-}
+// Get status banner using shared function
+const statusBanner = getStatusBanner(item.categories);
 %>
 
 ```{=html}
@@ -71,7 +59,10 @@ if (categories.includes('superseded')) {
         <% if (statusBanner) { %>
         <!-- Status Banner -->
         <div class="alert alert-<%= statusBanner.class %> status-banner mb-0 mt-2 rounded text-center py-1 px-2 small" role="alert">
-          <i class="bi bi-exclamation-triangle-fill"></i> <strong><%= statusBanner.text %></strong>
+          <% if (statusBanner.icon) { %>
+          <i class="bi <%= statusBanner.icon %>"></i>
+          <% } %>
+          <strong><%= statusBanner.text %></strong>
         </div>
         <% } %>
       </div>

--- a/assets/ejs/listing.ejs
+++ b/assets/ejs/listing.ejs
@@ -5,6 +5,26 @@ const excludeCategories = [
   'filter', 'filters',
   'shortcode', 'shortcodes'
 ];
+
+// Shared function to get status banner based on categories
+// Returns object with type, text, class, and icon
+// Priority: superseded > deprecated > archived > experimental > stable
+const getStatusBanner = (categories) => {
+  const lowerCategories = categories.map(c => c.toLowerCase());
+
+  if (lowerCategories.includes('superseded')) {
+    return { type: 'superseded', text: 'Superseded', class: 'warning', icon: 'bi-exclamation-triangle-fill' };
+  } else if (lowerCategories.includes('deprecated')) {
+    return { type: 'deprecated', text: 'Deprecated', class: 'warning', icon: 'bi-exclamation-triangle-fill' };
+  } else if (lowerCategories.includes('archived')) {
+    return { type: 'archived', text: 'Archived', class: 'secondary', icon: 'bi-archive-fill' };
+  } else if (lowerCategories.includes('experimental')) {
+    return { type: 'experimental', text: 'Experimental', class: 'info', icon: 'bi-flask' };
+  } else if (lowerCategories.includes('stable')) {
+    return { type: 'stable', text: 'Stable', class: 'success', icon: 'bi-check-circle-fill' };
+  }
+  return null;
+};
 %>
 
 :::: {#extensions-listing-container}
@@ -25,14 +45,14 @@ partial("_controls.ejs")
 <!-- Grid View -->
 :::: {#grid-view-container .view-container}
 <%
-partial("_grid.ejs", { items, excludeCategories, utils })
+partial("_grid.ejs", { items, excludeCategories, utils, getStatusBanner })
 %>
 ::::
 
 <!-- List View -->
 :::: {#list-view-container .view-container .d-none}
 <%
-partial("_list.ejs", { items, excludeCategories, utils })
+partial("_list.ejs", { items, excludeCategories, utils, getStatusBanner })
 %>
 ::::
 


### PR DESCRIPTION
Implement a shared function to retrieve status banners based on extension categories, enhancing code reusability and simplifying status management in both grid and list views.