### PR TITLE
chore: add further-reading extension to quarto-extensions.csv

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -280,3 +280,4 @@ wearetechnative/texnative
 wjschne/apaquarto
 zachcp/quarto-swissbiopics
 tomicapretto/quarto-carousel
+rodrigo-j-goncalves/further-reading


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
- [x] There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

<!-- Add a brief description of the extension. -->

`further-reading` is a customizable filter extension that automatically adds a _'Further reading' slide_ at the end of a revealjs presentation. 

That 'Further reading' slide shows a list of all external links used in the current presentation.


- Only _external links_ are listed. External links are links to sources outside the current presentation (`https://quarto.org/` is an external link)
-  Internal links are ignored. Internal links are links to slides within the current presentation (e.g. `[go to Results](#slide-id-results)` is an internal link)
- The Further reading slide can be customized (therefore used in different languages):
    - Slide title
    - Slide subtitle
    - Scroll message (when links do not fit into a single static slide, it turns into scrollable content)

`further-reading` extension is to be used in revealjs presentations (it may work with other formats, but it's not its main purpose).

This extension is inspired by , and heavily based on, J. Balamuta's [linkate](https://github.com/coatless-quarto/linkate).

The extra ingredients of 'further-reading' are:
- customizable slide (title, subtitle, scrolling message)
- only **external links** are listed (internal links are ignored)

