### PR TITLE
chore: Add michaelaye/fub-letter template

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -281,3 +281,4 @@ wjschne/apaquarto
 zachcp/quarto-swissbiopics
 tomicapretto/quarto-carousel
 rodrigo-j-goncalves/further-reading
+michaelaye/fub-letter


### PR DESCRIPTION
## Template Overview

This PR adds the **FU Berlin Letter Template** to the Quarto Extensions registry.

**Repository:** https://github.com/michaelaye/fub-letter

## Features

- ✅ Official Freie Universität Berlin corporate design (colors, logo, layout)
- ✅ Multi-language support (English/German)
- ✅ Language-aware defaults for greetings, closings, and subject labels
- ✅ Multiple template variants via subdirectories:
  - `quarto use template michaelaye/fub-letter/english` - English variant
  - `quarto use template michaelaye/fub-letter/german` - German variant
  - `quarto use template michaelaye/fub-letter` - Generic variant
- ✅ Clean markdown interface with LaTeX hidden in extension

## Examples

- 🇬🇧 [English example PDF](https://github.com/michaelaye/fub-letter/blob/main/english/_output/template.pdf)
- 🇩🇪 [German example PDF](https://github.com/michaelaye/fub-letter/blob/main/german/_output/template.pdf)

## GitHub Topics

Repository includes appropriate topics: `quarto`, `quarto-extension`, `quarto-template`, `letter`, `latex`, `corporate-design`, `fu-berlin`, `academic`