### PR TITLE
chore: rename data-wise/unm-revealjs to Data-Wise/dtslides

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -55,7 +55,7 @@ coursekata/quarto-inline-svg
 damoncharlesroberts/fancy-doc
 danmackinlay/quarto_tikz
 data-intuitive/quarto-d2
-data-wise/unm-revealjs
+Data-Wise/dtslides
 davidcarayon/quarto-inrae-extension
 dfalbel/chord-sheet
 dfolio/quarto-ieee


### PR DESCRIPTION
## Summary

The `unm-revealjs` extension has been renamed and expanded to **dtslides** (`Data-Wise/dtslides`).

- **Old entry:** `data-wise/unm-revealjs` (single UNM-branded theme)
- **New entry:** `Data-Wise/dtslides` (two themes — academic navy/slate + UNM cherry/turquoise)

This PR updates the existing listing entry to point to the new repository.

## Checklist

- [x] Repository has a description
- [x] Repository has topics: `academic`, `presentation`, `quarto`, `quarto-extension`, `revealjs`, `slides`, `stable`
- [x] Repository has a release tag (`v1.1.0`)
- [x] Repository contains `example.qmd` and `template.qmd` at root
- [x] Extension installs via `quarto add Data-Wise/dtslides`