### PR TITLE
chore: add progressvg extension to quarto-extensions.csv

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -283,3 +283,4 @@ tomicapretto/quarto-carousel
 rodrigo-j-goncalves/further-reading
 michaelaye/fub-letter
 wearetechnative/embed-sheet
+rodrigo-j-goncalves/progressvg


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Extension Submission

I confirm that I have checked that:

- [x ] I have checked that the extension GitHub repository has a description.
- [ x] I have checked that the extension GitHub repository has topics.

- [ x] The extension is not already listed.
- [ x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [ x] The GitHub repository contains **Topics**.
- [ x] The GitHub repository contains a **Release** with **Tag**.
- [ x] The GitHub repository has `example_simple.qmd` file.
- [ x] The GitHub repository has only one extension or a set of extensions.

## Description

In a Quarto@revealjs presentation, you can show/hide objects from a SVG file by usign their labels/IDs
