### PR TITLE
chore: add quarto-footnote-styles extension

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -3,6 +3,7 @@ andreasthinks/quarto-open-social-comments
 andrewheiss/fancy-epigraphs-quarto
 andrewheiss/hikmah-academic-quarto
 andrewheiss/language-name
+andrewheiss/quarto-footnote-styles
 andrewheiss/quarto-output-styling
 andrewheiss/quarto-wordcount
 andrie/reveal-auto-agenda


### PR DESCRIPTION
Added Quarto Footnote Styles extension (https://github.com/andrewheiss/quarto-footnote-styles)

<!--- Please provide a general summary of your changes in the title above -->

## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

This extension replaces Quarto’s default numeric footnote numbering with several alternative numbering systems (like *, †, ‡, §, ¶, **, ††, … or a, b, c, … z, aa, ab, …), inspired by Adobe InDesign's numbering styles. You can also define your own custom numbering system, as well as start numbering at any arbitrary value.

The extension supports HTML, LaTeX, and Typst (not Word)
