### PR TITLE
chore: add quarto-revealjs-fragmention extension

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -159,6 +159,7 @@ mcanouil/quarto-preview-colour
 mcanouil/quarto-remember
 mcanouil/quarto-revealjs-a11y
 mcanouil/quarto-revealjs-coeos
+mcanouil/quarto-revealjs-fragmention
 mcanouil/quarto-revealjs-storybook
 mcanouil/quarto-revealjs-tabset
 mcanouil/quarto-spotlight


### PR DESCRIPTION
Adds the `mcanouil/quarto-revealjs-fragmention` extension to the `quarto-extensions.csv` registry.