### PR TITLE
feat: display test render results in extensions gallery

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,9 +7,12 @@ project:
     - git restore --source=quarto-wizard quarto-extensions.json
     - mv quarto-extensions.json extensions.json
     - bash assets/scripts/generate-listing-data.sh
+    - bash -c "git fetch origin quarto-tests:quarto-tests || true"
+    - bash -c "git restore --source=quarto-tests test-results.json || echo '{}' > test-results.json"
   resources:
     - extensions.json
     - extensions-listing.json
+    - test-results.json
 
 date-meta: 2023-12-09
 
@@ -64,6 +67,7 @@ brand: _brand.yml
 
 format:
   mcanouil-html:
+    html-table-processing: none
     include-in-header:
       - text: |
           <style> #title-block-header, #quarto-appendix { display: none; } </style>

--- a/assets/ejs/_controls.ejs
+++ b/assets/ejs/_controls.ejs
@@ -35,6 +35,12 @@
   <button class="btn btn-sm btn-outline-warning filter-chip" data-filter="popular">
     <i class="bi bi-star-fill"></i> Popular
   </button>
+  <button class="btn btn-sm btn-outline-success filter-chip" data-filter="test-pass">
+    <i class="bi bi-check-circle-fill"></i> Passing
+  </button>
+  <button class="btn btn-sm btn-outline-danger filter-chip" data-filter="test-fail">
+    <i class="bi bi-x-circle-fill"></i> Failing
+  </button>
   <% const filterChips=[ { value: 'shortcode' , label: 'Shortcodes' , icon: 'bi-code-square' }, { value: 'filter' ,
     label: 'Filters' , icon: 'bi-funnel' }, { value: 'format' , label: 'Formats' , icon: 'bi-file-earmark-code' }, {
     value: 'project' , label: 'Projects' , icon: 'bi-folder' }, { value: 'revealjs-plugin' , label: 'Reveal.js Plugins'

--- a/assets/ejs/listing.ejs
+++ b/assets/ejs/listing.ejs
@@ -136,6 +136,49 @@ partial("_list.ejs", { items, excludeCategories, utils, getStatusBanner })
   }
 }
 
+/* Test status badges */
+.test-status-badges {
+  flex-wrap: wrap;
+}
+
+.test-badge-btn {
+  font-size: 0.75rem;
+  line-height: 1.2;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+  transition: background-color 0.15s ease-in-out;
+}
+
+.test-badge-btn:hover {
+  background-color: rgba(0, 0, 0, 0.075);
+}
+
+[data-bs-theme="dark"] .test-badge-btn:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.test-badge-btn i {
+  font-size: 0.8rem;
+}
+
+.test-status-badges-row {
+  min-height: 0;
+}
+
+#test-history-modal .table {
+  font-size: 0.875rem;
+}
+
+#test-history-modal code {
+  font-size: 0.8rem;
+}
+
 @media (max-width: 767px) {
   .btn-group {
     max-width: 100%;

--- a/assets/scripts/quarto-extensions-listing.html
+++ b/assets/scripts/quarto-extensions-listing.html
@@ -18,6 +18,12 @@
 
     // --- Extensions data (loaded asynchronously) ---
     let allExtensionsData = [];
+    let testResultsData = {};
+
+    // --- Test results constants ---
+    const REPO_URL = 'https://github.com/mcanouil/quarto-extensions';
+    const CHANNEL_LABELS = { release: 'Release', prerelease: 'Pre-release' };
+    const CHANNEL_ORDER = ['release', 'prerelease'];
 
     // --- Cache DOM elements ---
     const gridContainer = document.getElementById('grid-view-container');
@@ -106,6 +112,108 @@
       return null;
     }
 
+    // --- Test results helpers ---
+
+    function getLatestTestResults(usageKey) {
+      const key = usageKey.split('@')[0];
+      const entry = testResultsData[key];
+      if (!entry || !entry.results || entry.results.length === 0) return null;
+      const byChannel = {};
+      for (const r of entry.results) {
+        const ch = r.quarto_channel;
+        if (!byChannel[ch] || r.date > byChannel[ch].date) {
+          byChannel[ch] = r;
+        }
+      }
+      return { type: entry.type, latest: byChannel, allResults: entry.results };
+    }
+
+    function getTestStatusIcon(status) {
+      switch (status) {
+        case 'pass': return { icon: 'bi-check-circle-fill', colour: 'text-success', label: 'Pass' };
+        case 'fail': return { icon: 'bi-x-circle-fill', colour: 'text-danger', label: 'Fail' };
+        case 'skip': return { icon: 'bi-dash-circle-fill', colour: 'text-secondary', label: 'Skipped' };
+        default:     return { icon: 'bi-question-circle', colour: 'text-muted', label: 'Unknown' };
+      }
+    }
+
+    function renderTestBadges(usageKey, compact) {
+      const data = getLatestTestResults(usageKey);
+      if (!data) return '';
+      let html = '';
+      for (const ch of CHANNEL_ORDER) {
+        const result = data.latest[ch];
+        if (!result) continue;
+        const s = getTestStatusIcon(result.status);
+        const label = compact ? '' : ` ${CHANNEL_LABELS[ch] || ch}`;
+        const version = result.quarto_version;
+        html += `<button class="btn btn-link btn-sm p-0 test-badge-btn text-decoration-none"
+          data-usage="${escapeHtml(usageKey)}"
+          title="${s.label} on Quarto ${version} (${CHANNEL_LABELS[ch] || ch})">
+          <i class="bi ${s.icon} ${s.colour}"></i>
+          <span class="small text-muted">${escapeHtml(version)}${label}</span>
+        </button>`;
+      }
+      return html ? `<span class="test-status-badges d-inline-flex gap-2 align-items-center">${html}</span>` : '';
+    }
+
+    function renderTestHistoryModal(usageKey) {
+      const data = getLatestTestResults(usageKey);
+      if (!data) return '';
+      const key = usageKey.split('@')[0];
+      const byChannel = {};
+      for (const r of data.allResults) {
+        if (!byChannel[r.quarto_channel]) byChannel[r.quarto_channel] = [];
+        byChannel[r.quarto_channel].push(r);
+      }
+      for (const ch of Object.keys(byChannel)) {
+        byChannel[ch].sort((a, b) => b.date.localeCompare(a.date));
+      }
+      let channelsHtml = '';
+      for (const ch of CHANNEL_ORDER) {
+        const results = byChannel[ch];
+        if (!results) continue;
+        let rowsHtml = '';
+        for (const r of results) {
+          const s = getTestStatusIcon(r.status);
+          const logUrl = `${REPO_URL}/tree/quarto-tests/${r.log}`;
+          rowsHtml += `<tr>
+            <td><code>${escapeHtml(r.quarto_version)}</code></td>
+            <td><i class="bi ${s.icon} ${s.colour}"></i> ${s.label}</td>
+            <td>${escapeHtml(r.date)}</td>
+            <td><a href="${escapeHtml(logUrl)}" target="_blank" rel="noopener noreferrer" class="btn btn-outline-light btn-sm">
+              <i class="bi bi-file-text"></i> Logs
+            </a></td>
+          </tr>`;
+        }
+        channelsHtml += `
+          <h6 class="mt-3 mb-2">${CHANNEL_LABELS[ch] || ch} Channel</h6>
+          <div class="table-responsive">
+            <table class="table table-sm table-hover mb-0">
+              <thead><tr>
+                <th>Version</th><th>Status</th><th>Date</th><th>Logs</th>
+              </tr></thead>
+              <tbody>${rowsHtml}</tbody>
+            </table>
+          </div>`;
+      }
+      return `<div class="modal fade" id="test-history-modal" tabindex="-1" aria-labelledby="test-history-modal-label" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-lg">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title no-anchor" id="test-history-modal-label">
+                Test Results: <code>${escapeHtml(key)}</code>
+              </h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              ${channelsHtml}
+            </div>
+          </div>
+        </div>
+      </div>`;
+    }
+
     function renderCategoryBadges(categories, idPrefix, maxVisible) {
       const filtered = categories.filter(c => !EXCLUDE_CATEGORIES.includes(c.toLowerCase()));
       const main = filtered.slice(0, maxVisible);
@@ -156,6 +264,8 @@
         actionButtons += `<button class="btn btn-outline-info btn-sm flex-fill" data-bs-toggle="modal" data-bs-target="#use-modal-${sid}"><i class="bi bi-eye"></i> Use</button>`;
       }
 
+      const testBadgesHtml = renderTestBadges(item.usage, true);
+
       return `<div class="g-col-12 g-col-sm-6 g-col-lg-4">
     <div class="card extension-card h-100"
          data-categories="${escapeHtml(item.categories.join(','))}"
@@ -172,11 +282,12 @@
       </div>
       ${statusHtml}
       <div class="card-body d-flex flex-column">
+        <div class="d-flex justify-content-between align-items-center mb-1">
+          <div class="test-status-badges-row">${testBadgesHtml}</div>
+          <div>${templateBadge}${exampleBadge}</div>
+        </div>
         <h6 class="card-title d-flex align-items-center justify-content-between no-anchor extension-title">
-          <span>
-            <a href="${escapeHtml(item.githubUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.title)}</a>
-            ${templateBadge}${exampleBadge}
-          </span>
+          <a href="${escapeHtml(item.githubUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.title)}</a>
           <a href="${escapeHtml(item.githubUrl)}" target="_blank" rel="noopener noreferrer" class="btn btn-outline-light btn-sm ms-auto"><i class="bi bi-github"></i></a>
         </h6>
         <p class="card-text small text-muted mb-2">
@@ -234,6 +345,8 @@
         actionButtons += `<button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#use-modal-${sid}"><i class="bi bi-eye"></i> Use</button>`;
       }
 
+      const testBadgesHtml = renderTestBadges(item.usage, false);
+
       return `<div class="list-group-item extension-item"
        data-categories="${escapeHtml(item.categories.join(','))}"
        data-contributes="${escapeHtml(item.contributes.join(','))}"
@@ -250,11 +363,14 @@
         ${statusHtml}
       </div>
       <div class="flex-grow-1">
+        <div class="d-flex justify-content-between align-items-center mb-1">
+          <div class="test-status-badges-row">${testBadgesHtml}</div>
+          <div>${templateBadge}${exampleBadge}</div>
+        </div>
         <div class="extension-header d-flex justify-content-between align-items-center mb-2">
           <div class="extension-title-section">
             <h5 class="extension-title mb-0 no-anchor">
               <a href="${escapeHtml(item.githubUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.title)}</a>
-              ${templateBadge}${exampleBadge}
             </h5>
           </div>
           <div class="extension-metrics-header">
@@ -399,11 +515,21 @@ ${renderCodeBlock(`use template ${escapeHtml(item.usage)}`)}
       if (activeAuthorLogin) {
         if (item.login !== activeAuthorLogin) return false;
       }
-      // Category filters
+      // Category and test status filters
       if (activeFilters.size > 0) {
         const contributesLower = (item.contributes || []).map(v => v.toLowerCase().trim());
         for (const filter of activeFilters) {
-          if (FILTER_CHIP_VALUES.includes(filter)) {
+          if (filter === 'test-pass') {
+            const data = getLatestTestResults(item.usage);
+            if (!data) return false;
+            const hasPass = Object.values(data.latest).some(r => r.status === 'pass');
+            if (!hasPass) return false;
+          } else if (filter === 'test-fail') {
+            const data = getLatestTestResults(item.usage);
+            if (!data) return false;
+            const hasFail = Object.values(data.latest).some(r => r.status === 'fail');
+            if (!hasFail) return false;
+          } else if (FILTER_CHIP_VALUES.includes(filter)) {
             const hasMatch = contributesLower.some(val => val.startsWith(filter));
             if (!hasMatch) return false;
           }
@@ -573,6 +699,39 @@ ${renderCodeBlock(`use template ${escapeHtml(item.usage)}`)}
       // Open explicitly
       new bootstrap.Modal(modalEl).show();
     }, true); // Capture phase
+
+    // --- Test history modal ---
+
+    document.addEventListener('click', function (e) {
+      const badge = e.target.closest('.test-badge-btn');
+      if (!badge) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      const usageKey = badge.dataset.usage;
+      const existing = document.getElementById('test-history-modal');
+      if (existing) {
+        const bsModal = bootstrap.Modal.getInstance(existing);
+        if (bsModal) bsModal.dispose();
+        existing.remove();
+      }
+
+      const html = renderTestHistoryModal(usageKey);
+      if (!html) return;
+
+      const temp = document.createElement('div');
+      temp.innerHTML = html;
+      const modalEl = temp.firstElementChild;
+      document.body.appendChild(modalEl);
+
+      modalEl.addEventListener('hidden.bs.modal', function () {
+        const bsModal = bootstrap.Modal.getInstance(modalEl);
+        if (bsModal) bsModal.dispose();
+        modalEl.remove();
+      });
+
+      new bootstrap.Modal(modalEl).show();
+    }, true);
 
     // --- View toggle ---
 
@@ -787,17 +946,18 @@ ${renderCodeBlock(`use template ${escapeHtml(item.usage)}`)}
     if (gridCounterElement) gridCounterElement.textContent = gridRenderedCount;
     if (listCounterElement) listCounterElement.textContent = listRenderedCount;
 
-    // Fetch extensions data asynchronously for progressive loading, search, and filtering
-    fetch('extensions-listing.json')
-      .then(response => {
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        return response.json();
-      })
-      .then(data => {
-        allExtensionsData = data;
-        // Build lookup for on-demand modals
-        data.forEach(item => itemsById.set(item.id, item));
-        // Replace server-rendered items with properly sorted JS-rendered items
+    // Fetch extensions and test results data in parallel
+    Promise.all([
+      fetch('extensions-listing.json').then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      }),
+      fetch('test-results.json').then(r => r.ok ? r.json() : {}).catch(() => ({}))
+    ])
+      .then(([extensions, testResults]) => {
+        allExtensionsData = extensions;
+        testResultsData = testResults;
+        extensions.forEach(item => itemsById.set(item.id, item));
         rebuildView();
       })
       .catch(error => {

--- a/assets/scripts/quarto-extensions-listing.html
+++ b/assets/scripts/quarto-extensions-listing.html
@@ -149,7 +149,7 @@
         const version = result.quarto_version;
         html += `<button class="btn btn-link btn-sm p-0 test-badge-btn text-decoration-none"
           data-usage="${escapeHtml(usageKey)}"
-          title="${s.label} on Quarto ${version} (${CHANNEL_LABELS[ch] || ch})">
+          title="${s.label} on Quarto ${escapeHtml(version)} (${escapeHtml(CHANNEL_LABELS[ch] || ch)})">
           <i class="bi ${s.icon} ${s.colour}"></i>
           <span class="small text-muted">${escapeHtml(version)}${label}</span>
         </button>`;


### PR DESCRIPTION
Fetches test-results.json from the quarto-tests branch during pre-render and serves it as a static resource alongside extensions-listing.json. The JavaScript loads both files in parallel and renders pass/fail/skip badges on each extension card and list item, placed in a row above the title with template/example indicators on the right.

Clicking a badge opens a test history modal showing per-channel tables with Quarto version, status, date, and links to the log directories on GitHub.

Two new filter chips (Passing and Failing) allow narrowing extensions by their latest test status across any channel. Hover styles on badges follow light/dark mode via data-bs-theme scoping. The feature degrades gracefully when test-results.json is unavailable.