### PR TITLE
feat: display test render results in extensions gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /extensions/**/
 extensions.json
 extensions-listing.json
+test-results.json
 node_modules/
 package-lock.json
 package.json

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,6 +6,9 @@ project:
     - git restore --source=quarto-wizard --worktree "extensions"
     - git restore --source=quarto-wizard quarto-extensions.json
     - mv quarto-extensions.json extensions.json
+    - bash -c "git fetch origin quarto-tests:quarto-tests || true"
+    - bash -c "git restore --source=quarto-tests test-results.json || echo '{}' > test-results.json"
+    - bash assets/scripts/inject-test-results.sh
   resources:
     - extensions.json
 
@@ -62,6 +65,7 @@ brand: _brand.yml
 
 format:
   mcanouil-html:
+    html-table-processing: none
     include-in-header:
       - text: |
           <style> #title-block-header, #quarto-appendix { display: none; } </style>

--- a/assets/ejs/_controls.ejs
+++ b/assets/ejs/_controls.ejs
@@ -3,7 +3,7 @@
 ::: {.g-col-8}
 ```{=html}
 <div class="input-group">
-  <span class="input-group-text"><i class="bi bi-search"></i></span>
+  <span class="input-group-text"><i class="bi bi-search" aria-hidden="true"></i></span>
   <input type="text" id="extension-search" class="form-control" placeholder="Search extensions, authors, categories..."
     aria-label="Search extensions">
 </div>
@@ -14,11 +14,11 @@
 <div class="btn-group" role="group" aria-label="View toggle">
   <input type="radio" class="btn-check" name="view-toggle" id="grid-view" checked>
   <label class="btn btn-outline-light" for="grid-view">
-    <i class="bi bi-grid-3x3-gap"></i> Grid
+    <i class="bi bi-grid-3x3-gap" aria-hidden="true"></i> Grid
   </label>
   <input type="radio" class="btn-check d-none d-md-inline" name="view-toggle" id="list-view">
   <label class="btn btn-outline-light d-none d-md-inline" for="list-view">
-    <i class="bi bi-list-ul"></i> List
+    <i class="bi bi-list-ul" aria-hidden="true"></i> List
   </label>
 </div>
 ```
@@ -29,11 +29,17 @@
 :::: {.quick-filters .mb-3}
 ```{=html}
 <div class="d-flex flex-wrap gap-2 justify-content-center">
-  <button class="btn btn-sm btn-outline-success filter-chip" data-filter="recent">
-    <i class="bi bi-clock-history"></i> Recently Updated
+  <button class="btn btn-sm btn-outline-success filter-chip" data-filter="recent" aria-pressed="false">
+    <i class="bi bi-clock-history" aria-hidden="true"></i> Recently Updated
   </button>
-  <button class="btn btn-sm btn-outline-warning filter-chip" data-filter="popular">
-    <i class="bi bi-star-fill"></i> Popular
+  <button class="btn btn-sm btn-outline-warning filter-chip" data-filter="popular" aria-pressed="false">
+    <i class="bi bi-star-fill" aria-hidden="true"></i> Popular
+  </button>
+  <button class="btn btn-sm btn-outline-success filter-chip" data-filter="test-pass" aria-pressed="false">
+    <i class="bi bi-check-circle-fill" aria-hidden="true"></i> Passing
+  </button>
+  <button class="btn btn-sm btn-outline-danger filter-chip" data-filter="test-fail" aria-pressed="false">
+    <i class="bi bi-x-circle-fill" aria-hidden="true"></i> Failing
   </button>
   <% const filterChips=[ { value: 'shortcode' , label: 'Shortcodes' , icon: 'bi-code-square' }, { value: 'filter' ,
     label: 'Filters' , icon: 'bi-funnel' }, { value: 'format' , label: 'Formats' , icon: 'bi-file-earmark-code' }, {
@@ -41,19 +47,19 @@
     , icon: 'bi-sliders' }, { value: 'metadata' , label: 'Metadata' , icon: 'bi-info-circle' } ]; %>
     <div class="btn-group flex-wrap" role="group" aria-label="Category filters" style="max-width: 100%;">
       <% filterChips.forEach(function(chip) { %>
-        <button class="btn btn-sm btn-outline-primary filter-chip" data-filter="<%= chip.value %>">
-          <i class="bi <%= chip.icon %>"></i>
+        <button class="btn btn-sm btn-outline-primary filter-chip" data-filter="<%= chip.value %>" aria-label="<%= chip.label %>" aria-pressed="false">
+          <i class="bi <%= chip.icon %>" aria-hidden="true"></i>
           <span class="d-none d-sm-inline">
             <%= chip.label %>
           </span>
-          <span class="d-inline d-sm-none" aria-label="<%= chip.label %>">
+          <span class="d-inline d-sm-none" aria-hidden="true">
             <%= chip.label.charAt(0) %>
           </span>
         </button>
         <% }); %>
     </div>
     <button class="btn btn-sm btn-outline-light" id="clear-filters">
-      <i class="bi bi-x-circle"></i> Clear
+      <i class="bi bi-x-circle" aria-hidden="true"></i> Clear
     </button>
 </div>
 ```

--- a/assets/ejs/_grid.ejs
+++ b/assets/ejs/_grid.ejs
@@ -51,7 +51,8 @@ const statusBanner = getStatusBanner(item.categories);
          data-stars="<%= item.stars %>"
          data-modified="<%= item['file-modified'] %>"
          data-template="<%= isTemplate %>"
-         data-example="<%= isExample %>">
+         data-example="<%= isExample %>"
+         data-test-status="<%= item['test-results'] ? (item['test-results'].some(r => r.status === 'fail') ? 'fail' : item['test-results'].some(r => r.status === 'pass') ? 'pass' : 'skip') : 'none' %>">
       
       <!-- Card Header with Image -->
       <% let image = item.image; let imageAlt = item['image-alt']; if (!image) { image = "assets/media/github-placeholder.png"; imageAlt = "GitHub Placeholder Image"; } %>
@@ -63,7 +64,7 @@ const statusBanner = getStatusBanner(item.categories);
       <!-- Status Banner -->
       <div class="alert alert-<%= statusBanner.class %> status-banner mb-0 rounded-0 text-center py-1" role="alert">
         <% if (statusBanner.icon) { %>
-        <i class="bi <%= statusBanner.icon %>"></i>
+        <i class="bi <%= statusBanner.icon %>" aria-hidden="true"></i>
         <% } %>
         <strong><%= statusBanner.text %></strong>
       </div>
@@ -71,24 +72,48 @@ const statusBanner = getStatusBanner(item.categories);
 
       <!-- Card Body -->
       <div class="card-body d-flex flex-column">
-        <h6 class="card-title d-flex align-items-center justify-content-between no-anchor extension-title">
-          <span>
-            <a href="<%= item['github-url'] %>" target="_blank" rel="noopener noreferrer">
-              <%= item.title %>
-            </a>
+        <div class="d-flex justify-content-between align-items-center mb-1">
+          <div class="test-status-badges-row d-flex flex-wrap gap-1">
+            <% if (item['test-results']) {
+              const latestByChannel = {};
+              item['test-results'].forEach(r => {
+                const ch = r['quarto-channel'];
+                if (!latestByChannel[ch]) latestByChannel[ch] = r;
+              });
+              ['release', 'prerelease'].forEach(ch => {
+                const r = latestByChannel[ch];
+                if (!r) return;
+                const icon = r.status === 'pass' ? 'bi-check-circle-fill' : r.status === 'fail' ? 'bi-x-circle-fill' : 'bi-dash-circle-fill';
+                const colour = r.status === 'pass' ? 'text-success' : r.status === 'fail' ? 'text-danger' : 'text-secondary';
+            %>
+            <button class="test-badge-btn" type="button"
+                    data-bs-toggle="modal" data-bs-target="#test-history-modal-<%= id %>"
+                    data-usage="<%= usage %>"
+                    aria-label="<%= r.status.charAt(0).toUpperCase() + r.status.slice(1) %> on Quarto <%= r['quarto-version'] %> (<%= ch === 'prerelease' ? 'Pre-release' : 'Release' %>). View test history.">
+              <i class="bi <%= icon %> <%= colour %>" aria-hidden="true"></i>
+              <span class="<%= colour %>"><%= r['quarto-version'] %></span>
+            </button>
+            <% }); } %>
+          </div>
+          <div>
             <% if (isTemplate) { %>
             <span class="badge bg-success ms-1">Template</span>
             <% } %>
             <% if (isExample) { %>
             <span class="badge bg-info ms-1">Example</span>
             <% } %>
-          </span>
-          <a href="<%= item['github-url'] %>" target="_blank" rel="noopener noreferrer" class="btn btn-outline-light btn-sm ms-auto"><i class="bi bi-github"></i></a>
+          </div>
+        </div>
+        <h6 class="card-title d-flex align-items-center justify-content-between no-anchor extension-title">
+          <a href="<%= item['github-url'] %>" target="_blank" rel="noopener noreferrer">
+            <%= item.title %>
+          </a>
+          <a href="<%= item['github-url'] %>" target="_blank" rel="noopener noreferrer" class="btn btn-outline-light btn-sm ms-auto" aria-label="View <%= item.title %> on GitHub"><i class="bi bi-github" aria-hidden="true"></i></a>
         </h6>
         
         <p class="card-text small text-muted mb-2">
           <button class="btn btn-link p-0 text-muted text-decoration-none filter-chip" data-filter="author" data-login="<%= item.login %>">
-            <i class="bi bi-person"></i> <%= (!item.author || item.author === 'null') ? item.login : item.author %>
+            <i class="bi bi-person" aria-hidden="true"></i> <%= (!item.author || item.author === 'null') ? item.login : item.author %>
           </button>
         </p>
         
@@ -113,7 +138,7 @@ const statusBanner = getStatusBanner(item.categories);
               <% extraCategories.forEach(category => { %>
                 <span class="badge bg-light text-dark me-1 extra-category d-none" data-extra="<%= gridCatId %>"><%= category %></span>
               <% }); %>
-              <button class="btn btn-link btn-sm p-0 text-muted category-expand-toggle" type="button" data-id="<%= gridCatId %>">
+              <button class="btn btn-link btn-sm p-0 text-muted category-expand-toggle" type="button" data-id="<%= gridCatId %>" aria-expanded="false" aria-label="Show <%= extraCategories.length %> more categories">
                 +<%= extraCategories.length %>
               </button>
             <% } %>
@@ -123,10 +148,10 @@ const statusBanner = getStatusBanner(item.categories);
         <!-- Card Footer Info -->
         <div class="card-footer-info d-flex justify-content-between align-items-center small text-muted">
           <span>
-            <i class="bi bi-star-fill text-warning"></i> <%= item.stars %>
+            <i class="bi bi-star-fill text-warning" aria-hidden="true"></i> <span class="visually-hidden">Stars:</span> <%= item.stars %>
           </span>
           <span>
-            <i class="bi bi-clock"></i> <%= relativeTime %>
+            <i class="bi bi-clock" aria-hidden="true"></i> <span class="visually-hidden">Updated:</span> <%= relativeTime %>
           </span>
         </div>
       </div>
@@ -135,16 +160,16 @@ const statusBanner = getStatusBanner(item.categories);
       <div class="card-footer bg-transparent">
         <div class="d-flex gap-2 flex-wrap flex-sm-nowrap">
           <button class="btn btn-primary btn-sm flex-fill" data-bs-toggle="modal" data-bs-target="#install-modal-<%= id %>">
-            <i class="bi bi-download"></i> Install
+            <i class="bi bi-download" aria-hidden="true"></i> Install
           </button>
           <% if (isTemplate) { %>
           <button class="btn btn-outline-success btn-sm flex-fill" data-bs-toggle="modal" data-bs-target="#use-modal-<%= id %>">
-            <i class="bi bi-file-plus"></i> Use
+            <i class="bi bi-file-plus" aria-hidden="true"></i> Use
           </button>
           <% } %>
           <% if (isExample) { %>
           <button class="btn btn-outline-info btn-sm flex-fill" data-bs-toggle="modal" data-bs-target="#use-modal-<%= id %>">
-            <i class="bi bi-eye"></i> Use
+            <i class="bi bi-eye" aria-hidden="true"></i> Use
           </button>
           <% } %>
         </div>

--- a/assets/ejs/_list.ejs
+++ b/assets/ejs/_list.ejs
@@ -50,7 +50,8 @@ const statusBanner = getStatusBanner(item.categories);
        data-stars="<%= item.stars %>"
        data-modified="<%= item['file-modified'] %>"
        data-template="<%= isTemplate %>"
-       data-example="<%= isExample %>">
+       data-example="<%= isExample %>"
+       data-test-status="<%= item['test-results'] ? (item['test-results'].some(r => r.status === 'fail') ? 'fail' : item['test-results'].some(r => r.status === 'pass') ? 'pass' : 'skip') : 'none' %>">
     <div class="d-flex flex-column flex-md-row align-items-start">
       <!-- Extension Image -->
       <% let image = item.image; let imageAlt = item['image-alt']; if (!image) { image = "assets/media/github-placeholder.png"; imageAlt = "GitHub Placeholder Image"; } %>
@@ -60,7 +61,7 @@ const statusBanner = getStatusBanner(item.categories);
         <!-- Status Banner -->
         <div class="alert alert-<%= statusBanner.class %> status-banner mb-0 mt-2 rounded text-center py-1 px-2 small" role="alert">
           <% if (statusBanner.icon) { %>
-          <i class="bi <%= statusBanner.icon %>"></i>
+          <i class="bi <%= statusBanner.icon %>" aria-hidden="true"></i>
           <% } %>
           <strong><%= statusBanner.text %></strong>
         </div>
@@ -68,6 +69,39 @@ const statusBanner = getStatusBanner(item.categories);
       </div>
 
       <div class="flex-grow-1">
+        <div class="d-flex justify-content-between align-items-center mb-1">
+          <div class="test-status-badges-row d-flex flex-wrap gap-1">
+            <% if (item['test-results']) {
+              const latestByChannel = {};
+              item['test-results'].forEach(r => {
+                const ch = r['quarto-channel'];
+                if (!latestByChannel[ch]) latestByChannel[ch] = r;
+              });
+              ['release', 'prerelease'].forEach(ch => {
+                const r = latestByChannel[ch];
+                if (!r) return;
+                const icon = r.status === 'pass' ? 'bi-check-circle-fill' : r.status === 'fail' ? 'bi-x-circle-fill' : 'bi-dash-circle-fill';
+                const colour = r.status === 'pass' ? 'text-success' : r.status === 'fail' ? 'text-danger' : 'text-secondary';
+                const label = ch === 'prerelease' ? 'Pre-release' : 'Release';
+            %>
+            <button class="test-badge-btn" type="button"
+                    data-bs-toggle="modal" data-bs-target="#test-history-modal-<%= id %>"
+                    data-usage="<%= usage %>"
+                    aria-label="<%= r.status.charAt(0).toUpperCase() + r.status.slice(1) %> on Quarto <%= r['quarto-version'] %> (<%= label %>). View test history.">
+              <i class="bi <%= icon %> <%= colour %>" aria-hidden="true"></i>
+              <span class="<%= colour %>"><%= r['quarto-version'] %> (<%= label %>)</span>
+            </button>
+            <% }); } %>
+          </div>
+          <div>
+            <% if (isTemplate) { %>
+            <span class="badge bg-success ms-2">Template</span>
+            <% } %>
+            <% if (isExample) { %>
+            <span class="badge bg-info ms-2">Example</span>
+            <% } %>
+          </div>
+        </div>
         <!-- Extension Header -->
         <div class="extension-header d-flex justify-content-between align-items-center mb-2">
           <div class="extension-title-section">
@@ -75,12 +109,6 @@ const statusBanner = getStatusBanner(item.categories);
               <a href="<%= item['github-url'] %>" target="_blank" rel="noopener noreferrer">
                 <%= item.title %>
               </a>
-              <% if (isTemplate) { %>
-              <span class="badge bg-success ms-2">Template</span>
-              <% } %>
-              <% if (isExample) { %>
-              <span class="badge bg-info ms-2">Example</span>
-              <% } %>
             </h5>
           </div>
           
@@ -88,18 +116,18 @@ const statusBanner = getStatusBanner(item.categories);
           <div class="extension-metrics-header">
             <div class="d-flex gap-3 align-items-center">
               <span class="text-muted small">
-                <i class="bi bi-star-fill text-warning"></i> <%= item.stars %>
+                <i class="bi bi-star-fill text-warning" aria-hidden="true"></i> <span class="visually-hidden">Stars:</span> <%= item.stars %>
               </span>
               <span class="text-muted small">
-                <i class="bi bi-clock"></i> <%= relativeTime %>
+                <i class="bi bi-clock" aria-hidden="true"></i> <span class="visually-hidden">Updated:</span> <%= relativeTime %>
               </span>
               <% if (item.license && item.license !== 'none') { %>
               <span class="text-muted small">
-                <i class="bi bi-file-text"></i> <%= item.license %>
+                <i class="bi bi-file-text" aria-hidden="true"></i> <span class="visually-hidden">Licence:</span> <%= item.license %>
               </span>
               <% } %>
-              <a href="<%= item['github-url'] %>" target="_blank" rel="noopener noreferrer" class="btn btn-outline-light btn-sm">
-                <i class="bi bi-github"></i>
+              <a href="<%= item['github-url'] %>" target="_blank" rel="noopener noreferrer" class="btn btn-outline-light btn-sm" aria-label="View <%= item.title %> on GitHub">
+                <i class="bi bi-github" aria-hidden="true"></i>
               </a>
             </div>
           </div>
@@ -109,7 +137,7 @@ const statusBanner = getStatusBanner(item.categories);
         <div class="extension-content">
           <div class="extension-author mb-1">
             <button class="btn btn-link p-0 text-muted text-decoration-none filter-chip" data-filter="author" data-login="<%= item.login %>">
-              <i class="bi bi-person"></i> <%= (!item.author || item.author === 'null') ? item.login : item.author %>
+              <i class="bi bi-person" aria-hidden="true"></i> <%= (!item.author || item.author === 'null') ? item.login : item.author %>
             </button>
           </div>
           <div class="extension-description mb-2">
@@ -135,7 +163,7 @@ const statusBanner = getStatusBanner(item.categories);
                 <% extraCategories.forEach(category => { %>
                   <span class="badge bg-light text-dark me-1 extra-category d-none" data-extra="<%= listCatId %>"><%= category %></span>
                 <% }); %>
-                <button class="btn btn-link btn-sm p-0 text-muted category-expand-toggle" type="button" data-id="<%= listCatId %>">
+                <button class="btn btn-link btn-sm p-0 text-muted category-expand-toggle" type="button" data-id="<%= listCatId %>" aria-expanded="false" aria-label="Show <%= extraCategories.length %> more categories">
                   +<%= extraCategories.length %> more
                 </button>
               <% } %>
@@ -144,16 +172,16 @@ const statusBanner = getStatusBanner(item.categories);
           
           <div class="extension-actions">
             <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#install-modal-<%= id %>">
-              <i class="bi bi-download"></i> Install
+              <i class="bi bi-download" aria-hidden="true"></i> Install
             </button>
             <% if (isTemplate) { %>
             <button class="btn btn-outline-success btn-sm" data-bs-toggle="modal" data-bs-target="#use-modal-<%= id %>">
-              <i class="bi bi-file-plus"></i> Use
+              <i class="bi bi-file-plus" aria-hidden="true"></i> Use
             </button>
             <% } %>
             <% if (isExample) { %>
             <button class="btn btn-outline-info btn-sm" data-bs-toggle="modal" data-bs-target="#use-modal-<%= id %>">
-              <i class="bi bi-eye"></i> Use
+              <i class="bi bi-eye" aria-hidden="true"></i> Use
             </button>
             <% } %>
           </div>

--- a/assets/ejs/_modal-test-history.ejs
+++ b/assets/ejs/_modal-test-history.ejs
@@ -1,0 +1,61 @@
+```{=html}
+<div class="modal fade" id="test-history-modal-<%= id %>" tabindex="-1" aria-labelledby="test-history-modal-label-<%= id %>" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title no-anchor" id="test-history-modal-label-<%= id %>">
+          Test Results: <code><%= key %></code>
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <%
+        const CHANNEL_ORDER = ['release', 'prerelease'];
+        const CHANNEL_LABELS = { release: 'Release', prerelease: 'Pre-release' };
+
+        // Group results by channel
+        const byChannel = {};
+        testResults.forEach(r => {
+          const ch = r['quarto-channel'] || 'unknown';
+          if (!byChannel[ch]) byChannel[ch] = [];
+          byChannel[ch].push(r);
+        });
+
+        // Sort each channel by date descending
+        for (const ch of Object.keys(byChannel)) {
+          byChannel[ch].sort((a, b) => (b.date || '').localeCompare(a.date || ''));
+        }
+
+        for (const ch of CHANNEL_ORDER) {
+          const items = byChannel[ch];
+          if (!items) continue;
+        %>
+        <h6 class="mt-3 mb-2"><%= CHANNEL_LABELS[ch] || ch %> Channel</h6>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr><th scope="col">Version</th><th scope="col">Status</th><th scope="col">Date</th><th scope="col">Logs</th></tr>
+            </thead>
+            <tbody>
+              <% items.forEach(r => {
+                const icon = r.status === 'pass' ? 'bi-check-circle-fill' : r.status === 'fail' ? 'bi-x-circle-fill' : 'bi-dash-circle-fill';
+                const colour = r.status === 'pass' ? 'text-success' : r.status === 'fail' ? 'text-danger' : 'text-secondary';
+                const statusLabel = r.status.charAt(0).toUpperCase() + r.status.slice(1);
+                const logUrl = 'https://github.com/mcanouil/quarto-extensions/tree/quarto-tests/' + r.log;
+              %>
+              <tr>
+                <td><code><%= r['quarto-version'] %></code></td>
+                <td><i class="bi <%= icon %> <%= colour %>" aria-hidden="true"></i> <%= statusLabel %></td>
+                <td><%= r.date %></td>
+                <td><a href="<%= logUrl %>" target="_blank" rel="noopener noreferrer" class="btn btn-outline-light btn-sm" aria-label="View logs for Quarto <%= r['quarto-version'] %>"><i class="bi bi-file-text" aria-hidden="true"></i> Logs</a></td>
+              </tr>
+              <% }); %>
+            </tbody>
+          </table>
+        </div>
+        <% } %>
+      </div>
+    </div>
+  </div>
+</div>
+```

--- a/assets/ejs/listing.ejs
+++ b/assets/ejs/listing.ejs
@@ -61,11 +61,15 @@ partial("_list.ejs", { items, excludeCategories, utils, getStatusBanner })
 <%
 const usage = item.usage;
 const id = utils.b64encode(usage);
+const key = usage.split('@')[0];
 const isTemplate = item.template === true;
 const isExample = item.example === true;
 partial("_modal-install.ejs", { id, usage });
 if (isTemplate || isExample) {
   partial("_modal-use.ejs", { id, usage });
+}
+if (item['test-results'] && item['test-results'].length > 0) {
+  partial("_modal-test-history.ejs", { id, key, testResults: item['test-results'] });
 }
 %>
 <% } %>
@@ -82,6 +86,14 @@ if (isTemplate || isExample) {
 }
 .extension-card {
   border-color: var(--bs-border-colour, #dee2e6);
+}
+.extension-card .btn:hover,
+.extension-item .btn:hover,
+.modal .btn:hover {
+  transform: none;
+}
+.modal .btn-group {
+  width: 100%;
 }
 .card-footer {
   border-color: var(--bs-border-colour, #dee2e6);
@@ -135,6 +147,39 @@ if (isTemplate || isExample) {
       display: none;
     }
   }
+}
+
+.test-status-badges-row {
+  min-height: 0;
+}
+.test-badge-btn {
+  font-size: 0.75rem;
+  line-height: 1.2;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+  transition: background-color 0.15s ease-in-out;
+}
+.test-badge-btn:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+  transform: scale(1.05);
+}
+[data-bs-theme="dark"] .test-badge-btn:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+.test-badge-btn i {
+  font-size: 0.8rem;
+}
+#test-history-modal .table {
+  font-size: 0.875rem;
+}
+#test-history-modal code {
+  font-size: 0.8rem;
 }
 
 @media (max-width: 767px) {

--- a/assets/scripts/inject-test-results.sh
+++ b/assets/scripts/inject-test-results.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inject test results from test-results.json into extension.yml files.
+# Each extension.yml gets a test-results YAML block appended if matching
+# results exist in test-results.json.
+
+RESULTS_FILE="test-results.json"
+
+if [[ ! -f "${RESULTS_FILE}" ]]; then
+	echo "No ${RESULTS_FILE} found, skipping injection."
+	exit 0
+fi
+
+for yml_path in extensions/*/extension.yml extensions/*/*/extension.yml; do
+	[[ -f "${yml_path}" ]] || continue
+
+	# Extract usage field (e.g., "owner/repo" or "owner/repo@v1.0")
+	usage=$(grep -m1 '^[[:space:]]*usage:' "${yml_path}" | sed 's/^[[:space:]]*usage:[[:space:]]*//' | xargs)
+	[[ -z "${usage}" ]] && continue
+
+	# Strip @version to get the test-results.json key
+	key="${usage%%@*}"
+
+	# Check if this extension has test results
+	results=$(jq -r --arg k "${key}" '.[$k].results // empty' "${RESULTS_FILE}")
+	[[ -z "${results}" ]] && continue
+
+	count=$(jq -r --arg k "${key}" '.[$k].results | length' "${RESULTS_FILE}")
+	[[ "${count}" -eq 0 ]] && continue
+
+	# Build YAML block and append
+	{
+		echo "  test-results:"
+		jq -r --arg k "${key}" '
+      .[$k].results[] |
+      "    - quarto-version: \"" + .quarto_version + "\"\n" +
+      "      quarto-channel: \"" + .quarto_channel + "\"\n" +
+      "      status: \"" + .status + "\"\n" +
+      "      log: \"" + .log + "\"\n" +
+      "      date: \"" + .date + "\""
+    ' "${RESULTS_FILE}"
+	} >>"${yml_path}"
+done

--- a/assets/scripts/quarto-extensions-listing.html
+++ b/assets/scripts/quarto-extensions-listing.html
@@ -355,11 +355,22 @@
           if (show && activeFilters.size > 0) {
             const contributes = (ext.dataset.contributes || '').toLowerCase().split(',');
             const contributesSet = new Set(contributes.map(val => val.trim()));
+            const testStatus = ext.dataset.testStatus || 'none';
 
             for (const filter of activeFilters) {
               if (filterChipValues.includes(filter)) {
                 const hasMatch = Array.from(contributesSet).some(val => val.startsWith(filter));
                 if (!hasMatch) {
+                  show = false;
+                  break;
+                }
+              } else if (filter === 'test-pass') {
+                if (testStatus !== 'pass') {
+                  show = false;
+                  break;
+                }
+              } else if (filter === 'test-fail') {
+                if (testStatus !== 'fail') {
                   show = false;
                   break;
                 }
@@ -486,6 +497,7 @@
         }
       });
     });
+
   });
 </script>
 <!-- Custom JavaScript for clipboard.js to properly access code inside modals -->


### PR DESCRIPTION
Inject test results from the quarto-tests branch into extension listings at build time via a pre-render shell script that appends test-results YAML to each extension.yml.

Each extension card and list item shows pass/fail badges per Quarto channel (release/pre-release) linking to a modal with full test history and log links.
Adds Passing and Failing quick-filter chips to the filter bar.
Improves accessibility with aria-hidden on decorative icons, aria-pressed on toggle buttons, aria-labels on interactive elements, and visually-hidden text for screen readers.