### PR TITLE
revert: "ci: get quarto-web extensions"

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -304,4 +304,3 @@ EllaKaye/localtime
 herosi/table-cell-merge
 dkapitan/quarto-revealjs-mozilla
 simonreif/academic-cv-quarto
-sebastiansauer/quarto-typst-academic-template


### PR DESCRIPTION
Reverts mcanouil/quarto-extensions#297

The extension added has malformed tags and malformed manifest for those tags making it impossible to add it.

- https://github.com/sebastiansauer/quarto-typst-academic-template/issues/2