### PR TITLE
fix(ci): skip malformed _extension.yml instead of aborting run

### DIFF
--- a/.github/scripts/quarto-wizard/lib/extension.sh
+++ b/.github/scripts/quarto-wizard/lib/extension.sh
@@ -24,17 +24,23 @@ extract_extension_manifest() {
     return
   fi
 
-  # Extract both fields with yq in single pass, then aggregate with jq
-  echo "${extension_files}" |
-    while read -r url; do
-      gh api "${url}" --jq '.content' | base64 --decode | yq -o json '{
-        "contributes": (.contributes | keys // []),
-        "quartoRequired": (."quarto-required" // null)
-      }'
-    done | jq -s '{
-      contributes: (map(.contributes) | add | map(select(. != null)) | map(if type=="string" then sub("s$"; "") else . end) | unique),
-      quartoRequired: (map(.quartoRequired) | map(select(. != null)) | if length > 0 then first else null end)
-    }'
+  # Extract both fields with yq per file; skip unparseable manifests with a warning
+  # so one malformed _extension.yml does not abort the whole run.
+  while IFS= read -r url; do
+    local yaml_content parsed
+    yaml_content=$(gh api "${url}" --jq '.content' | base64 --decode)
+    if ! parsed=$(printf '%s' "${yaml_content}" | yq -o json '{
+      "contributes": (.contributes | keys // []),
+      "quartoRequired": (."quarto-required" // null)
+    }' 2>/dev/null); then
+      echo "::warning title=Invalid Extension Manifest::${repo}@${repo_branch} ${url}" >&2
+      continue
+    fi
+    printf '%s\n' "${parsed}"
+  done <<< "${extension_files}" | jq -s '{
+    contributes: ([.[].contributes // empty] | add // [] | map(select(. != null)) | map(if type=="string" then sub("s$"; "") else . end) | unique),
+    quartoRequired: (map(.quartoRequired) | map(select(. != null)) | if length > 0 then first else null end)
+  }'
 }
 
 # Main function to process extensions from CSV


### PR DESCRIPTION
A single `_extension.yml` that fails YAML parsing was enough to abort the whole `Quarto Wizard` run via `set -e -o pipefail`, leaving every other entry unprocessed.
This happened on run [24622834684](https://github.com/mcanouil/quarto-extensions/actions/runs/24622834684) when processing `sebastiansauer/quarto-typst-academic-template` at its `zenodo` release tag, where `_extensions/aufsatz/_extension.yml` contains an unquoted colon in the title value.

`extract_extension_manifest` now guards each `yq` invocation, emits a `::warning title=Invalid Extension Manifest::...` annotation on failure, and continues to the next file.
The `jq` aggregator defaults to an empty array so a stream with no parseable manifests no longer triggers `Cannot iterate over null`.