### PR TITLE
Add quarto-quartable extension to quarto-extensions.csv

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -306,3 +306,4 @@ wearetechnative/embed-sheet
 wearetechnative/texnative
 wjschne/apaquarto
 zachcp/quarto-swissbiopics
+zinc75/quarto-quartable


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

Quarto extension for better tables handling : column spans, row spans, midrules, clines, vertical lines and per-cell alignment for Markdown pipe tables — HTML, Reveal.js and PDF/LaTeX. Aims at obtaining good looking tables for publication-ready articles or webpages and presentations - heavily influenced by the LaTeX package booktabs in its philisophy and look and feel. 