### PR TITLE
fix(ci): drop inline rebuild fallback and serialise build-matrix

### DIFF
--- a/.github/docker/test-extensions/Dockerfile
+++ b/.github/docker/test-extensions/Dockerfile
@@ -47,7 +47,7 @@ USER vscode
 
 # Python virtual environment with Jupyter and common packages
 ENV UV_LINK_MODE=copy
-RUN uv venv --allow-existing /home/vscode/.venv \
+RUN uv venv /home/vscode/.venv \
     && . /home/vscode/.venv/bin/activate \
     && uv pip install jupyter papermill matplotlib shinylive
 ENV VIRTUAL_ENV=/home/vscode/.venv

--- a/.github/docker/test-extensions/Dockerfile
+++ b/.github/docker/test-extensions/Dockerfile
@@ -47,7 +47,7 @@ USER vscode
 
 # Python virtual environment with Jupyter and common packages
 ENV UV_LINK_MODE=copy
-RUN uv venv /home/vscode/.venv \
+RUN uv venv --allow-existing /home/vscode/.venv \
     && . /home/vscode/.venv/bin/activate \
     && uv pip install jupyter papermill matplotlib shinylive
 ENV VIRTUAL_ENV=/home/vscode/.venv

--- a/.github/scripts/test-extensions/build-matrix.sh
+++ b/.github/scripts/test-extensions/build-matrix.sh
@@ -200,42 +200,15 @@ for channel in release prerelease; do
     echo "::error::Resolved image reference '${image_ref}' is not a valid digest-pinned reference."
     exit 1
   fi
-  if docker run --rm --user root \
-    --cap-drop=ALL --read-only --network=none \
-    "${image_ref}" bash -lc '
-    set -euo pipefail
-    dpkg -s \
-      jq \
-      libcurl4-openssl-dev \
-      libssl-dev \
-      libxml2-dev \
-      libfontconfig1-dev \
-      libharfbuzz-dev \
-      libfribidi-dev \
-      libfreetype6-dev \
-      libpng-dev \
-      libtiff5-dev \
-      libjpeg-dev \
-      libgit2-dev \
-      zlib1g-dev \
-      cmake >/dev/null 2>&1
-  '; then
-    is_ready=true
-  else
-    is_ready=false
-  fi
   image_meta_map=$(echo "${image_meta_map}" | jq \
     --arg ch "${channel}" \
     --arg ref "${image_ref}" \
-    --argjson ready "${is_ready}" \
-    '. + {($ch): {image_ref: $ref, image_ready: $ready}}')
+    '. + {($ch): {image_ref: $ref}}')
 done
 
 if ! echo "${image_meta_map}" | jq -e '
   (.release.image_ref | type == "string")
   and (.prerelease.image_ref | type == "string")
-  and (.release.image_ready | type == "boolean")
-  and (.prerelease.image_ready | type == "boolean")
 ' >/dev/null 2>&1; then
   echo "::error::Image metadata is incomplete."
   exit 1
@@ -261,14 +234,12 @@ matrix=$(echo "${entries}" | jq -c --argjson n "${BATCH_SIZE}" --argjson meta "$
             batch_index: (0 | pad3),
             quarto_channel: "release",
             image_ref: $meta.release.image_ref,
-            image_ready: $meta.release.image_ready,
             extensions: []
           },
           {
             batch_index: (0 | pad3),
             quarto_channel: "prerelease",
             image_ref: $meta.prerelease.image_ref,
-            image_ready: $meta.prerelease.image_ready,
             extensions: []
           }
         ]
@@ -287,14 +258,12 @@ matrix=$(echo "${entries}" | jq -c --argjson n "${BATCH_SIZE}" --argjson meta "$
                       batch_index: ($bi | pad3),
                       quarto_channel: "release",
                       image_ref: $meta.release.image_ref,
-                      image_ready: $meta.release.image_ready,
                       extensions: $all[$s:($s + $n)]
                     },
                     {
                       batch_index: ($bi | pad3),
                       quarto_channel: "prerelease",
                       image_ref: $meta.prerelease.image_ref,
-                      image_ready: $meta.prerelease.image_ready,
                       extensions: $all[$s:($s + $n)]
                     }
                   ]

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       skipped: ${{ steps.matrix.outputs.skipped }}
@@ -68,7 +67,7 @@ jobs:
 
   test-extensions:
     name: test-extensions (batch ${{ matrix.batch_index }}, ${{ matrix.quarto_channel }})
-    needs: [build-test-image, build-matrix]
+    needs: [build-matrix]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -82,7 +81,6 @@ jobs:
         shell: bash
     env:
       IMAGE: ${{ matrix.image_ref }}
-      IMAGE_READY: ${{ matrix.image_ready }}
       QUARTO_CHANNEL: ${{ matrix.quarto_channel }}
     steps:
       - name: Checkout scripts
@@ -116,40 +114,8 @@ jobs:
             echo "::error::Image reference '${IMAGE}' is not a valid digest-pinned reference."
             exit 1
           fi
-          if [[ "${IMAGE_READY}" == "true" ]]; then
-            docker pull "${IMAGE}"
-            docker tag "${IMAGE}" render-image
-          else
-            echo "::notice::IMAGE_READY=false for ${QUARTO_CHANNEL}. Rebuilding from inline Dockerfile (~15 min overhead)."
-            docker build \
-              --build-arg BASE_IMAGE="${IMAGE}" \
-              --build-arg HOST_UID="$(id -u)" \
-              --build-arg HOST_GID="$(id -g)" \
-              -t render-image - <<'DOCKERFILE'
-          ARG BASE_IMAGE
-          ARG HOST_UID=1000
-          ARG HOST_GID=1000
-          FROM ${BASE_IMAGE}
-          USER root
-          RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
-              jq libcurl4-openssl-dev libssl-dev libxml2-dev libfontconfig1-dev \
-              libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev \
-              libtiff5-dev libjpeg-dev libwebp-dev libgit2-dev zlib1g-dev cmake \
-              ghostscript \
-              && rm -rf /var/lib/apt/lists/*
-          RUN Rscript -e 'install.packages(c("rmarkdown", "knitr", "reticulate", "ggplot2", "dplyr", "tidyverse", "kableExtra", "palmerpenguins", "gt", "tibble", "ragg"), repos = "https://cloud.r-project.org", lib = .Library)'
-          ARG HOST_UID
-          ARG HOST_GID
-          RUN if [ -d /opt/tinytex ]; then chown -R ${HOST_UID}:${HOST_GID} /opt/tinytex; fi
-          USER vscode
-          ENV UV_LINK_MODE=copy
-          RUN uv venv --allow-existing /home/vscode/.venv \
-              && . /home/vscode/.venv/bin/activate \
-              && uv pip install jupyter papermill matplotlib shinylive
-          ENV VIRTUAL_ENV=/home/vscode/.venv
-          ENV PATH="/home/vscode/.venv/bin:${PATH}"
-          DOCKERFILE
-          fi
+          docker pull "${IMAGE}"
+          docker tag "${IMAGE}" render-image
 
       - name: Clone extensions
         if: steps.inspect-batch.outputs.count != '0'

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -24,9 +24,11 @@ jobs:
       packages: write
 
   build-matrix:
+    needs: [build-test-image]
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       skipped: ${{ steps.matrix.outputs.skipped }}
@@ -141,7 +143,7 @@ jobs:
           RUN if [ -d /opt/tinytex ]; then chown -R ${HOST_UID}:${HOST_GID} /opt/tinytex; fi
           USER vscode
           ENV UV_LINK_MODE=copy
-          RUN uv venv /home/vscode/.venv \
+          RUN uv venv --allow-existing /home/vscode/.venv \
               && . /home/vscode/.venv/bin/activate \
               && uv pip install jupyter papermill matplotlib shinylive
           ENV VIRTUAL_ENV=/home/vscode/.venv


### PR DESCRIPTION
The inline rebuild fallback in `test-extensions` failed when the test image it layered on already contained `/home/vscode/.venv`, because `uv venv` refuses to clobber an existing environment.
The fallback was a verbatim copy of `.github/docker/test-extensions/Dockerfile` minus the LaTeX block, so it duplicated the apt list, the R install, and the venv setup.

`build-matrix` now declares `needs: [build-test-image]`, so the digest the matrix captures is always the freshly pushed one.
That makes the fallback unreachable, so it is removed along with the `IMAGE_READY` env, the `image_ready` matrix field, and the `dpkg` readiness probe in `build-matrix.sh` that produced it.
`test-extensions.needs` is reduced to `[build-matrix]` since the dependency on `build-test-image` is now transitive.