### PR TITLE
chore: add a project setup template

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -307,3 +307,4 @@ wearetechnative/texnative
 wjschne/apaquarto
 zachcp/quarto-swissbiopics
 zinc75/quarto-quartable
+simonreif/zewwwwEcon


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [ ] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

The zewwwwEcon package allows to set up new projects for reproducible empirical research using Quarto. A project contains templates and some ggplot2 style adjustments to generate PDFs for Slides and Papers.

[For this type of template, it does not make sense to have a single `example.qmd` or `template.qmd` file. It contains different examples in a dedicated folder as well as template files also in dedicated folders. This relates to this discussion: https://github.com/mcanouil/quarto-extensions/issues/301#issuecomment-4427732288 ]
