### PR TITLE
ci: link _extensions into nested test/example projects

### DIFF
--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -387,6 +387,20 @@ render_single_qmd() {
   fi
 }
 
+# Extension dev repos keep _extensions at the repo root and symlink it into
+# example/test subprojects, where the link is typically gitignored. Recreate
+# those links so nested _quarto.yml projects resolve the extension when their
+# documents are rendered individually.
+root_ext="$(pwd)/_extensions"
+if [[ -d "${root_ext}" ]]; then
+  while IFS= read -r -d '' qy; do
+    proj_dir="$(dirname "${qy}")"
+    [[ "${proj_dir}" == "." ]] && continue
+    [[ -e "${proj_dir}/_extensions" ]] && continue
+    ln -s "${root_ext}" "${proj_dir}/_extensions"
+  done < <(find . \( -name _quarto.yml -o -name _quarto.yaml \) -not -path './_extensions/*' -print0)
+fi
+
 if [[ -f _quarto.yml ]] || [[ -f _quarto.yaml ]]; then
   quarto_render "project" || exit 1
 elif [[ "${EXT_TYPE}" == "document" ]]; then


### PR DESCRIPTION
## Context

CI render of `emilhvitfeldt/quarto-revealjs-editable` failed:

```
ERROR: Specified Reveal plugin directory 'editable' does not exist.
```

This is a test-setup issue, not an extension bug.

## Root cause

Extension dev repos keep `_extensions/` at the repo root and symlink it into example/test subprojects, where the link is gitignored (e.g. `testing/run-tests.sh` does `ln -s ../_extensions _extensions`). The harness renders each `.qmd` individually, so Quarto detects the nested `_quarto.yml` (e.g. `testing/_quarto.yml`) as the project root and scopes extension resolution to the missing nested `_extensions`. Extensions defined at the repo root are never found.

## Fix

Before rendering, for each nested `_quarto.yml`/`_quarto.yaml` lacking `_extensions`, symlink the repo-root `_extensions` in. Mirrors the dev convention; skips dirs that already have a real install.

## Verification

Reproduced locally and confirmed the fix:

- `testing/modify-mode-all.qmd` → revealjs: now renders.
- root `example.qmd` → revealjs: still renders.
- `docs/index.qmd`: still renders.

`shfmt -d` clean; `shellcheck` reports only the pre-existing SC1091 info on the sourced config.