### PR TITLE
chore: add quarto-proofread-comments extension

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -324,6 +324,7 @@ wjschne/apaquarto
 zachcp/quarto-swissbiopics
 zinc75/quarto-quartable
 zinc75/quarto-cnam-thesis
+zinc75/quarto-proofread-comments
 simonreif/zewwwwEcon
 luismmontilla/quarto-altmetrics/
 crisbour/bytefield


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

Collaborative proofreading annotations for Quarto using pandoc bracketed-span syntax `[…]{.comment …}`:

- **Insert** a margin comment, or **highlight a span and attach a note** to it.
- Four kinds: `comment`, `todo`, `note`, `question`; coloured per reviewer (auto-assigned or custom).
- **HTML**: margin callouts, flowing marker-pen highlights, inline badges, hover linking between an anchor and its note.
- **PDF/LaTeX**: `todonotes` margin notes (numbered or bézier connector), `soulpos` marker-pen highlights that break cleanly across lines, columns and pages, flowing inline badges, and wide-margin / two-column layouts.
- Toggle everything off with `enabled: false` for the final version.

Install: `quarto add zinc75/quarto-proofread-comments`
Docs: https://zinc75.github.io/quarto-proofread-comments/