### PR TITLE
chore: add quarto-static-photo-gallery

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -5,6 +5,7 @@ andrewheiss/hikmah-academic-quarto
 andrewheiss/language-name
 andrewheiss/quarto-footnote-styles
 andrewheiss/quarto-output-styling
+andrewheiss/quarto-static-photo-gallery
 andrewheiss/quarto-wordcount
 andrie/reveal-auto-agenda
 arcruz0/quarto-compact


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file. (it has a whole website with examples)
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

Quarto extension for building photo galleries from static images through PhotoSwipe