### PR TITLE
chore: add lsbjordao/quarto-scientific-writing

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -335,3 +335,4 @@ tiagojct/quarto-study-flow
 robjhyndman/quarto-ims-journals
 ihrke/quarto-cambridge
 maucejo/quarto-bookly
+lsbjordao/quarto-scientific-writing


### PR DESCRIPTION
Adds `lsbjordao/quarto-scientific-writing` to the extensions listing.