### PR TITLE
chore: add quarto-revealjs-terminal extension

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -337,3 +337,4 @@ robjhyndman/quarto-ims-journals
 ihrke/quarto-cambridge
 maucejo/quarto-bookly
 lsbjordao/quarto-scientific-writing
+rpodcast/quarto-revealjs-terminal


### PR DESCRIPTION
## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

A retro computer-terminal theme for Quarto Reveal.js presentations.
