### PR TITLE
chore: add new quarto extension 'jiangyun-fun/quarto-passage-xref'

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -127,9 +127,9 @@ herosi/Zoomit-ish
 holtzy/lumo
 hrbrmstr/quarto-organization-template
 iagopinal/figure-table-formatter
-iangyun-fun/quarto-passage-xref
 ihrke/mdpi
 inseefrlab/onyxia-quarto
+jiangyun-fun/quarto-passage-xref
 jimjam-slam/quarto-svelte
 jjallaire/code-visibility
 jjdeclercq/alert_shortcode

--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -127,6 +127,7 @@ herosi/Zoomit-ish
 holtzy/lumo
 hrbrmstr/quarto-organization-template
 iagopinal/figure-table-formatter
+iangyun-fun/quarto-passage-xref
 ihrke/mdpi
 inseefrlab/onyxia-quarto
 jimjam-slam/quarto-svelte


### PR DESCRIPTION
## Description

> This adds the **passage-xref** extension to the `shortcodes-and-filters` listing.
> 
> ## About
> `passage-xref` is a Lua filter that adds cross-references for **arbitrary inline text passages** — something Quarto's native cross-reference system doesn't support.
> 
> Features:
> 
> * Auto-numbered inline passage targets: `[text]{.passage #pas-xxx}`
> * Clickable numbered references: `[Passage]{.pref pas="pas-xxx"}`
> * Custom prefix / no-prefix options
> * HTML hover previews (reuses Quarto's built-in tippy.js)
> * Forward references (collect + resolve passes)
> * Tolerant of bracket text and attributes split across lines
> 
> ## Listing requirements
> * ✅ Hosted on GitHub: https://github.com/jiangyun-fun/quarto-passage-xref
> * ✅ `README.md` with installation instructions and usage examples
> * ✅ Open-source license: MIT (`LICENSE`)
> * ✅ Installs cleanly via `quarto add jiangyun-fun/quarto-passage-xref`
> 
> ## Live preview
> https://jiangyun-fun.github.io/quarto-passage-xref/

CC. @jiangyun-fun adding your cool extension, before automatic addition from quarto-web repository.
