### PR TITLE
chore: add shortiquiz and stepbystep extensions

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -339,3 +339,5 @@ ihrke/quarto-cambridge
 maucejo/quarto-bookly
 lsbjordao/quarto-scientific-writing
 rpodcast/quarto-revealjs-terminal
+skyfroger/stepbystep
+skyfroger/shortiquiz


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

I am adding two separate extensions. Both extension comply with checklist above.

### Shortiquiz
Add interactive quiz questions to Quarto HTML documents: multiple-choice, text input, Parsons problems, flashcards, image hotspots, and more.

### Stepbystep
Organize step-by-step tasks, track learner progress with checkboxes, and create interactive image highlighting with hotspots and tooltips.