### PR TITLE
ci: valorise extension submission PRs

### DIFF
--- a/.github/workflows/check-extensions.yml
+++ b/.github/workflows/check-extensions.yml
@@ -447,6 +447,8 @@ jobs:
 
           CSV_FILE_ENCODED=$(echo -n "${CSV_FILE}" | hexdump -v -e '/1 "%02x"' | sed 's/\(..\)/%\1/g')
 
+          declare -A mention_owners
+
           errors_found=false
           if [[ "${DUPLICATE_RESULT}" == "failure" || \
                 "${TOPICS_RESULT}" == "failure" || \
@@ -485,6 +487,7 @@ jobs:
 
             for line_number in $(echo "${!file_line_errors[@]}" | tr ' ' '\n' | sort -n); do
               entry=$(sed -n "${line_number}p" ${CSV_FILE})
+              mention_owners["${entry%%/*}"]=1
               echo "### Line [${line_number}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${NUMBER}/files#diff-${CSV_FILE_ENCODED}L${line_number}): [\`${entry}\`](${GITHUB_SERVER_URL}/${entry})" >> "${GITHUB_STEP_SUMMARY}"
               echo "" >> "${GITHUB_STEP_SUMMARY}"
               echo -e "${file_line_errors[${line_number}]}" >> "${GITHUB_STEP_SUMMARY}"
@@ -516,11 +519,22 @@ jobs:
 
             for line_number in $(echo "${!file_line_notes[@]}" | tr ' ' '\n' | sort -n); do
               entry=$(sed -n "${line_number}p" ${CSV_FILE})
+              mention_owners["${entry%%/*}"]=1
               echo "#### Line [${line_number}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${NUMBER}/files#diff-${CSV_FILE_ENCODED}L${line_number}): [\`${entry}\`](${GITHUB_SERVER_URL}/${entry})" >> "${GITHUB_STEP_SUMMARY}"
               echo "" >> "${GITHUB_STEP_SUMMARY}"
               echo -e "${file_line_notes[${line_number}]}" >> "${GITHUB_STEP_SUMMARY}"
               echo "" >> "${GITHUB_STEP_SUMMARY}"
             done
+          fi
+
+          if [[ ${#mention_owners[@]} -gt 0 ]]; then
+            mentions=""
+            for owner in $(echo "${!mention_owners[@]}" | tr ' ' '\n' | sort); do
+              mentions+="@${owner} "
+            done
+            echo "---" >> "${GITHUB_STEP_SUMMARY}"
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+            echo "cc ${mentions% }" >> "${GITHUB_STEP_SUMMARY}"
           fi
 
           mkdir -p ./extensions-check-summary

--- a/.github/workflows/valorise-submission.yml
+++ b/.github/workflows/valorise-submission.yml
@@ -1,0 +1,66 @@
+name: Valorise Submission
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - "Check Extensions"
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  valorise:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_KEY }}
+      - name: Download artifact
+        id: download-artifact
+        continue-on-error: true
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: extensions-check-summary
+          path: "${{ runner.temp }}/artifacts/"
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ steps.app-token.outputs.token }}
+      - name: Normalise title and label
+        if: steps.download-artifact.outputs.download-path != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DOWNLOAD_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        shell: bash
+        run: |
+          PR_NUMBER=$(cat "${DOWNLOAD_PATH}/pr_number")
+          TITLE=$(gh pr view "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --json title --jq .title)
+          LOWER=$(echo "${TITLE}" | tr '[:upper:]' '[:lower:]')
+          if echo "${LOWER}" | grep -qE '^[a-z]+(\([^)]*\))?!?:[[:space:]]'; then
+            NEW_TITLE="${LOWER}"
+          else
+            NEW_TITLE="chore: ${LOWER}"
+          fi
+          if [[ "${TITLE}" != "${NEW_TITLE}" ]]; then
+            gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --title "${NEW_TITLE}"
+          fi
+          gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "Type: Valorisation :tada:"
+      - name: Workflow completion
+        env:
+          DOWNLOAD_PATH: ${{ steps.download-artifact.outputs.download-path }}
+        run: |
+          if [[ "${DOWNLOAD_PATH}" == "" ]]; then
+            echo "ℹ️ No artifacts found, workflow completed successfully"
+            echo "ℹ️ No artifacts found, workflow completed successfully" >> "${GITHUB_STEP_SUMMARY}"
+          fi


### PR DESCRIPTION
## Summary

- Add `Valorise Submission` workflow (`.github/workflows/valorise-submission.yml`) reacting to `Check Extensions` completion via `workflow_run`, so it works on fork PRs through the GitHub App token.
  - Normalises the PR title: lower-cased, `chore: ` prefix added only when the title has no existing one-word conventional prefix (`feat:`, `fix:`, `chore(deps):`, ...).
  - Adds the `Type: Valorisation :tada:` label.
- Append a `cc @owner` footer to the `Extension Check Summary` comment that mentions the repository owner of each flagged line (errors and suggestions). No footer on clean submissions.

## Title transform examples

| Before | After |
| --- | --- |
| `Add Musify Extension` | `chore: add musify extension` |
| `feat!: Big Thing` | `feat!: big thing` |
| `chore(deps): bump X` | `chore(deps): bump x` |

## Verification

- YAML parse and `shellcheck` on the inline script pass.
- `actionlint` not run locally (not installed, Docker unavailable); relies on CI.