### PR TITLE
chore: add klausagnoletti/quarto-slide-foundation

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -343,3 +343,4 @@ skyfroger/stepbystep
 skyfroger/shortiquiz
 jtkulas/callout-png
 sebastiandelbano/musify
+klausagnoletti/quarto-slide-foundation


### PR DESCRIPTION
Adds **quarto-slide-foundation**, a theme-agnostic reveal.js slide foundation: one L0 role-token contract (colour + treatment tokens, including motion) plus an 11-element library authored purely against it. A theme is just an implementation of the contract; set the `:root` tokens and the whole element set re-skins.

Requirements checklist:
- [x] Repository description
- [x] Topics (including `quarto-extension`)
- [x] Release with tag (`v0.1.0`)
- [x] `example.qmd` present
- [x] Single extension under `_extensions/`
- [x] Open-source license (MIT)

Repo: https://github.com/klausagnoletti/quarto-slide-foundation