### PR TITLE
fix: remove songwupei/quarto-gbt9704 from extensions list

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -347,4 +347,3 @@ klausagnoletti/quarto-slide-foundation
 nessan/admonitions
 nessan/simple-vars
 WEHI-ResearchComputing/QuartoCards
-songwupei/quarto-gbt9704


### PR DESCRIPTION
The extension from @songwupei is not a valid extension thus has to be removed.

- https://github.com/songwupei/quarto-gbt9704/issues/1