### PR TITLE
chore: add jimjam-slam/quarto-tab-selector

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -131,6 +131,7 @@ ihrke/mdpi
 inseefrlab/onyxia-quarto
 jiangyun-fun/quarto-passage-xref
 jimjam-slam/quarto-svelte
+jimjam-slam/quarto-tab-selector
 jjallaire/code-visibility
 jjdeclercq/alert_shortcode
 jlgraves-ubc/forms


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

A [Quarto](https://quarto.org/) extension that replaces the buttons in [Quarto Tabsets](https://quarto.org/docs/output-formats/html-basics.html#tabsets) with a `<select>` input (ie. a dropdown menu). If you use tabsets with many or long tabs, use this extension to ensure the page flows well. Extension works out of the box in 'auto' mode, switching to a dropdown when tabs run over the page, but can be configured to always make the switch or to work only at breakpoints or on numbers of tabs.
