### PR TITLE
chore: add rkskmt/quarto-cleanslidekit-revealjs

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -348,3 +348,4 @@ klausagnoletti/quarto-slide-foundation
 nessan/admonitions
 nessan/simple-vars
 WEHI-ResearchComputing/QuartoCards
+rkskmt/quarto-cleanslidekit-revealjs


### PR DESCRIPTION
## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

CleanSlideKit RevealJS is a batteries-included Reveal.js theme and UI kit for Quarto slides: clean styling plus a table-of-contents drawer, in-deck search, slide overview, title badges, and single-slide peek navigation. MIT licensed.

Release: https://github.com/rkskmt/quarto-cleanslidekit-revealjs/releases/tag/v1.5.1
Live demo: https://rkskmt.github.io/quarto-cleanslidekit-revealjs/
