### PR TITLE
ci: improve extension test framework and add submission pre-flight render

### DIFF
--- a/.github/docker/test-extensions/Dockerfile
+++ b/.github/docker/test-extensions/Dockerfile
@@ -29,7 +29,7 @@ RUN Rscript -e 'Sys.setenv(DOWNLOAD_STATIC_LIBV8 = "1"); \
 
 # Common LaTeX packages to avoid runtime CTAN mirror dependency
 RUN if command -v tlmgr >/dev/null 2>&1; then \
-    tlmgr update --self || true; \
+    tlmgr update --self; \
     tlmgr install \
       beamer pgf xcolor geometry hyperref booktabs \
       caption float fancyhdr enumitem titlesec \

--- a/.github/scripts/check-extensions/.shellcheckrc
+++ b/.github/scripts/check-extensions/.shellcheckrc
@@ -1,0 +1,3 @@
+# ShellCheck configuration for check-extensions scripts
+shell=bash
+external-sources=true

--- a/.github/scripts/check-extensions/check-description.sh
+++ b/.github/scripts/check-extensions/check-description.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 
 while IFS=, read -r entry; do
-	repo=$(echo "${entry}" | cut -d'/' -f1-2)
+	repo=$(entry_repo "${entry}")
 	repo_description=$(gh repo view --json description "${repo}" --jq ".description")
 	if [[ -z "${repo_description}" ]]; then
 		add_error "${entry}" "Repository is missing description."

--- a/.github/scripts/check-extensions/check-description.sh
+++ b/.github/scripts/check-extensions/check-description.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Flag added repositories without a description.
+# Inputs (env): DIFF, CSV_FILE, GITHUB_OUTPUT, GITHUB_TOKEN
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+while IFS=, read -r entry; do
+	repo=$(echo "${entry}" | cut -d'/' -f1-2)
+	repo_description=$(gh repo view --json description "${repo}" --jq ".description")
+	if [[ -z "${repo_description}" ]]; then
+		add_error "${entry}" "Repository is missing description."
+	fi
+done < <(read_diff_entries)
+
+write_check_outputs
+fail_if_errors

--- a/.github/scripts/check-extensions/check-duplicate.sh
+++ b/.github/scripts/check-extensions/check-duplicate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Flag duplicated entries in the extensions CSV.
+# Inputs (env): CSV_FILE, GITHUB_OUTPUT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+while IFS= read -r duplicate; do
+	while IFS= read -r line_number; do
+		add_error_at "${line_number}" "Repository is duplicated."
+	done < <(grep -n "${duplicate}" "${CSV_FILE}" | cut -d: -f1 | tail -n +2)
+done < <(sort -f "${CSV_FILE}" | uniq -di)
+
+write_check_outputs
+fail_if_errors

--- a/.github/scripts/check-extensions/check-redirection.sh
+++ b/.github/scripts/check-extensions/check-redirection.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 
 while IFS=, read -r entry; do
-	repo=$(echo "${entry}" | cut -d'/' -f1-2)
+	repo=$(entry_repo "${entry}")
 	if curl -I -s "https://github.com/${repo}" | grep -q "HTTP/.* 30[127]"; then
 		redirection_target=$(curl -Ls -o /dev/null -w "%{url_effective}" "https://github.com/${repo}")
 		redirection_target=${redirection_target#"https://github.com/"}

--- a/.github/scripts/check-extensions/check-redirection.sh
+++ b/.github/scripts/check-extensions/check-redirection.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Flag added repositories that redirect (renamed or transferred).
+# Inputs (env): DIFF, CSV_FILE, GITHUB_OUTPUT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+while IFS=, read -r entry; do
+	repo=$(echo "${entry}" | cut -d'/' -f1-2)
+	if curl -I -s "https://github.com/${repo}" | grep -q "HTTP/.* 30[127]"; then
+		redirection_target=$(curl -Ls -o /dev/null -w "%{url_effective}" "https://github.com/${repo}")
+		redirection_target=${redirection_target#"https://github.com/"}
+		add_error "${entry}" "Repository is redirected to \"${redirection_target}\"."
+	fi
+done < <(read_diff_entries)
+
+write_check_outputs
+fail_if_errors

--- a/.github/scripts/check-extensions/check-release.sh
+++ b/.github/scripts/check-extensions/check-release.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Flag added repositories without a release or tag.
+# Inputs (env): DIFF, CSV_FILE, GITHUB_OUTPUT, GITHUB_TOKEN
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+while IFS=, read -r entry; do
+	repo=$(echo "${entry}" | cut -d'/' -f1-2)
+	repo_release=$(gh repo view --json latestRelease "${repo}" --jq ".latestRelease")
+	if [[ -z "${repo_release}" ]]; then
+		add_error "${entry}" "Repository is missing release/tag."
+	fi
+done < <(read_diff_entries)
+
+write_check_outputs
+fail_if_errors

--- a/.github/scripts/check-extensions/check-release.sh
+++ b/.github/scripts/check-extensions/check-release.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 
 while IFS=, read -r entry; do
-	repo=$(echo "${entry}" | cut -d'/' -f1-2)
+	repo=$(entry_repo "${entry}")
 	repo_release=$(gh repo view --json latestRelease "${repo}" --jq ".latestRelease")
 	if [[ -z "${repo_release}" ]]; then
 		add_error "${entry}" "Repository is missing release/tag."

--- a/.github/scripts/check-extensions/check-structure.sh
+++ b/.github/scripts/check-extensions/check-structure.sh
@@ -9,10 +9,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 
 while IFS=, read -r entry; do
-	repo=$(echo "${entry}" | cut -d'/' -f1-2)
-	subdir=$(echo "${entry}" | cut -d'/' -f3-)
+	repo=$(entry_repo "${entry}")
+	subdir=$(entry_subdir "${entry}")
 
-	tree=$(gh api "repos/${repo}/git/trees/HEAD?recursive=1" --jq '.tree[].path' 2>/dev/null || true)
+	tree=$(fetch_repo_tree "${repo}")
 
 	if [[ -z "${tree}" ]]; then
 		add_error "${entry}" "Could not retrieve repository file tree to verify the extension structure."

--- a/.github/scripts/check-extensions/check-structure.sh
+++ b/.github/scripts/check-extensions/check-structure.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Flag added repositories without a valid Quarto extension structure.
+# Inputs (env): DIFF, CSV_FILE, GITHUB_OUTPUT, GITHUB_TOKEN
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+while IFS=, read -r entry; do
+	repo=$(echo "${entry}" | cut -d'/' -f1-2)
+	subdir=$(echo "${entry}" | cut -d'/' -f3-)
+
+	tree=$(gh api "repos/${repo}/git/trees/HEAD?recursive=1" --jq '.tree[].path' 2>/dev/null || true)
+
+	if [[ -z "${tree}" ]]; then
+		add_error "${entry}" "Could not retrieve repository file tree to verify the extension structure."
+		continue
+	fi
+
+	ext_prefix="${subdir:+${subdir}/}"
+
+	has_extension=$(echo "${tree}" | grep -E "^${ext_prefix}_extensions/[^/]+/_extension\.ya?ml$" | head -n 1 || true)
+	if [[ -z "${has_extension}" ]]; then
+		add_error "${entry}" "Repository is missing a valid Quarto extension structure (\`_extensions/<name>/_extension.yml\`)."
+	fi
+done < <(read_diff_entries)
+
+write_check_outputs
+fail_if_errors

--- a/.github/scripts/check-extensions/check-topics.sh
+++ b/.github/scripts/check-extensions/check-topics.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 
 while IFS=, read -r entry; do
-	repo=$(echo "${entry}" | cut -d'/' -f1-2)
+	repo=$(entry_repo "${entry}")
 	repo_topics=$(gh repo view --json repositoryTopics "${repo}" --jq ".repositoryTopics | length")
 	if [[ "${repo_topics}" -eq 0 ]]; then
 		add_error "${entry}" "Repository is missing topics."

--- a/.github/scripts/check-extensions/check-topics.sh
+++ b/.github/scripts/check-extensions/check-topics.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Flag added repositories without GitHub topics.
+# Inputs (env): DIFF, CSV_FILE, GITHUB_OUTPUT, GITHUB_TOKEN
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+while IFS=, read -r entry; do
+	repo=$(echo "${entry}" | cut -d'/' -f1-2)
+	repo_topics=$(gh repo view --json repositoryTopics "${repo}" --jq ".repositoryTopics | length")
+	if [[ "${repo_topics}" -eq 0 ]]; then
+		add_error "${entry}" "Repository is missing topics."
+	fi
+done < <(read_diff_entries)
+
+write_check_outputs
+fail_if_errors

--- a/.github/scripts/check-extensions/check-wizard.sh
+++ b/.github/scripts/check-extensions/check-wizard.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Suggest Quarto Wizard support (schema/snippets) for added extensions.
+# Advisory only: emits notes, never errors.
+# Inputs (env): DIFF, CSV_FILE, GITHUB_OUTPUT, GITHUB_TOKEN
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+while IFS=, read -r entry; do
+	repo=$(echo "${entry}" | cut -d'/' -f1-2)
+	subdir=$(echo "${entry}" | cut -d'/' -f3-)
+
+	tree=$(gh api "repos/${repo}/git/trees/HEAD?recursive=1" --jq '.tree[].path' 2>/dev/null || true)
+	if [[ -z "${tree}" ]]; then
+		continue
+	fi
+
+	if [[ -n "${subdir}" ]]; then
+		ext_prefix="${subdir}/"
+	else
+		ext_prefix=""
+	fi
+
+	has_extension=$(echo "${tree}" | grep -E "^${ext_prefix}_extensions/[^/]+/_extension\.yml$" | head -n 1 || true)
+	if [[ -z "${has_extension}" ]]; then
+		continue
+	fi
+
+	ext_dir=$(dirname "${has_extension}")
+
+	has_schema=$(echo "${tree}" | grep -E "^${ext_dir}/_schema\.(yml|yaml|json)$" || true)
+	has_snippets=$(echo "${tree}" | grep -E "^${ext_dir}/_snippets\.json$" || true)
+
+	if [[ -z "${has_schema}" && -z "${has_snippets}" ]]; then
+		missing="schema (\`_schema.yml\`) and snippets (\`_snippets.json\`) files"
+	elif [[ -z "${has_schema}" ]]; then
+		missing="schema (\`_schema.yml\`) file"
+	elif [[ -z "${has_snippets}" ]]; then
+		missing="snippets (\`_snippets.json\`) file"
+	else
+		continue
+	fi
+
+	add_note "${entry}" "Extension is missing ${missing}. Consider adding [Quarto Wizard](https://m.canouil.dev/quarto-wizard/) support to provide autocompletion, validation, hover documentation, and code snippets in editors. See [Schema Specification](https://m.canouil.dev/quarto-wizard/reference/schema-specification.html) and [Snippet Specification](https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html)."
+done < <(read_diff_entries)
+
+write_check_outputs

--- a/.github/scripts/check-extensions/check-wizard.sh
+++ b/.github/scripts/check-extensions/check-wizard.sh
@@ -10,19 +10,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 
 while IFS=, read -r entry; do
-	repo=$(echo "${entry}" | cut -d'/' -f1-2)
-	subdir=$(echo "${entry}" | cut -d'/' -f3-)
+	repo=$(entry_repo "${entry}")
+	subdir=$(entry_subdir "${entry}")
 
-	tree=$(gh api "repos/${repo}/git/trees/HEAD?recursive=1" --jq '.tree[].path' 2>/dev/null || true)
+	tree=$(fetch_repo_tree "${repo}")
 	if [[ -z "${tree}" ]]; then
 		continue
 	fi
 
-	if [[ -n "${subdir}" ]]; then
-		ext_prefix="${subdir}/"
-	else
-		ext_prefix=""
-	fi
+	ext_prefix="${subdir:+${subdir}/}"
 
 	has_extension=$(echo "${tree}" | grep -E "^${ext_prefix}_extensions/[^/]+/_extension\.yml$" | head -n 1 || true)
 	if [[ -z "${has_extension}" ]]; then

--- a/.github/scripts/check-extensions/lib.sh
+++ b/.github/scripts/check-extensions/lib.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Shared helpers for check-extensions scripts. Source this file; do not
+# execute it directly.
+# Requires env: CSV_FILE, GITHUB_OUTPUT. Optional: DIFF (base64-encoded
+# added CSV lines).
+
+errors_json="[]"
+notes_json="[]"
+
+# Print the added CSV entries from the base64-encoded DIFF, one per line.
+read_diff_entries() {
+	echo "${DIFF:-}" | base64 --decode | sed '/^$/d'
+}
+
+# Print the last CSV line number containing the given string.
+csv_line_number() {
+	local needle="$1"
+	grep -n -F -- "${needle}" "${CSV_FILE}" | cut -d: -f1 | tail -n 1
+}
+
+add_error_at() {
+	local line="$1" message="$2"
+	errors_json=$(echo "${errors_json}" | jq -c \
+		--arg line "${line}" \
+		--arg message "${message}" \
+		'. += [{"line": $line, "message": $message}]')
+}
+
+add_error() {
+	add_error_at "$(csv_line_number "$1")" "$2"
+}
+
+add_note_at() {
+	local line="$1" message="$2"
+	notes_json=$(echo "${notes_json}" | jq -c \
+		--arg line "${line}" \
+		--arg message "${message}" \
+		'. += [{"line": $line, "message": $message}]')
+}
+
+add_note() {
+	add_note_at "$(csv_line_number "$1")" "$2"
+}
+
+# Write errors/notes step outputs.
+write_check_outputs() {
+	{
+		echo "errors=${errors_json}"
+		echo "notes=${notes_json}"
+	} >>"${GITHUB_OUTPUT}"
+}
+
+# Exit non-zero when any error was recorded (blocking check semantics).
+fail_if_errors() {
+	if [[ "${errors_json}" != "[]" ]]; then
+		exit 1
+	fi
+}

--- a/.github/scripts/check-extensions/lib.sh
+++ b/.github/scripts/check-extensions/lib.sh
@@ -4,6 +4,10 @@
 # Requires env: CSV_FILE, GITHUB_OUTPUT. Optional: DIFF (base64-encoded
 # added CSV lines).
 
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../test-extensions/retry.sh
+source "${LIB_DIR}/../test-extensions/retry.sh"
+
 errors_json="[]"
 notes_json="[]"
 
@@ -12,18 +16,40 @@ read_diff_entries() {
 	echo "${DIFF:-}" | base64 --decode | sed '/^$/d'
 }
 
+# owner/repo part of a CSV entry (owner/repo[/subdir]).
+entry_repo() {
+	echo "$1" | cut -d'/' -f1-2
+}
+
+# subdir part of a CSV entry, without any trailing slash; empty when absent.
+entry_subdir() {
+	local subdir
+	subdir=$(echo "$1" | cut -d'/' -f3-)
+	echo "${subdir%/}"
+}
+
+# Print the repository tree paths (one per line); empty output on failure.
+fetch_repo_tree() {
+	local repo="$1"
+	retry 3 2 gh api "repos/${repo}/git/trees/HEAD?recursive=1" --jq '.tree[]? | .path' 2>/dev/null || true
+}
+
 # Print the last CSV line number containing the given string.
 csv_line_number() {
 	local needle="$1"
 	grep -n -F -- "${needle}" "${CSV_FILE}" | cut -d: -f1 | tail -n 1
 }
 
+append_line_message() {
+	local -n target="$1"
+	target=$(jq -c \
+		--arg line "$2" \
+		--arg message "$3" \
+		'. += [{"line": $line, "message": $message}]' <<<"${target}")
+}
+
 add_error_at() {
-	local line="$1" message="$2"
-	errors_json=$(echo "${errors_json}" | jq -c \
-		--arg line "${line}" \
-		--arg message "${message}" \
-		'. += [{"line": $line, "message": $message}]')
+	append_line_message errors_json "$1" "$2"
 }
 
 add_error() {
@@ -31,11 +57,7 @@ add_error() {
 }
 
 add_note_at() {
-	local line="$1" message="$2"
-	notes_json=$(echo "${notes_json}" | jq -c \
-		--arg line "${line}" \
-		--arg message "${message}" \
-		'. += [{"line": $line, "message": $message}]')
+	append_line_message notes_json "$1" "$2"
 }
 
 add_note() {

--- a/.github/scripts/check-extensions/preflight-render.sh
+++ b/.github/scripts/check-extensions/preflight-render.sh
@@ -5,23 +5,21 @@ set -euo pipefail
 # Reuses the test-extensions harness; results are reported via step outputs
 # (picked up by the summary job and sticky PR comment) and are never
 # committed anywhere. Logs are uploaded as workflow artefacts only.
-# Inputs (env): DIFF (base64-encoded added CSV lines), CSV_FILE,
+# Inputs (env): DIFF (base64-encoded added CSV lines), CSV_FILE, IMAGE,
 #               GITHUB_WORKSPACE, GITHUB_OUTPUT, GITHUB_TOKEN
-# Inputs (env, optional): IMAGE (default ghcr.io/mcanouil/quarto-extensions:release),
-#               QUARTO_CHANNEL (default release), MAX_PREFLIGHT_ENTRIES (default 5),
-#               BLOCKING (default false)
-# Outputs (GITHUB_OUTPUT): errors, notes (JSON arrays of {line, message})
+# Inputs (env, optional): QUARTO_CHANNEL (default release),
+#               MAX_PREFLIGHT_ENTRIES (default 5), BLOCKING (default false)
+# Outputs (GITHUB_OUTPUT): errors (blocking failures), notes (passes, skips,
+#               and advisory failures) — JSON arrays of {line, message}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEST_SCRIPTS_DIR="${SCRIPT_DIR}/../test-extensions"
 # shellcheck source=lib.sh
 source "${SCRIPT_DIR}/lib.sh"
-# shellcheck source=../test-extensions/retry.sh
-source "${TEST_SCRIPTS_DIR}/retry.sh"
 # shellcheck source=../test-extensions/classify-extension.sh
 source "${TEST_SCRIPTS_DIR}/classify-extension.sh"
 
-IMAGE="${IMAGE:-ghcr.io/mcanouil/quarto-extensions:release}"
+IMAGE="${IMAGE:?IMAGE is required (e.g. ghcr.io/<owner>/<repo>:release)}"
 QUARTO_CHANNEL="${QUARTO_CHANNEL:-release}"
 MAX_PREFLIGHT_ENTRIES="${MAX_PREFLIGHT_ENTRIES:-5}"
 BLOCKING="${BLOCKING:-false}"
@@ -50,9 +48,8 @@ for entry in "${entries[@]}"; do
 		add_note "${entry}" "Pre-flight render skipped: entry format not recognised."
 		continue
 	fi
-	repo=$(echo "${entry}" | cut -d'/' -f1-2)
-	subdir=$(echo "${entry}" | cut -d'/' -f3- -s)
-	subdir="${subdir%/}"
+	repo=$(entry_repo "${entry}")
+	subdir=$(entry_subdir "${entry}")
 
 	# One render per repository: a second entry for the same repo (different
 	# subdir) would clash with the first in the id-keyed results.
@@ -61,8 +58,8 @@ for entry in "${entries[@]}"; do
 		continue
 	fi
 
-	if ! tree=$(retry 3 2 gh api "repos/${repo}/git/trees/HEAD?recursive=1" --jq '.tree[]? | .path' 2>/dev/null) ||
-		[[ -z "${tree}" ]]; then
+	tree=$(fetch_repo_tree "${repo}")
+	if [[ -z "${tree}" ]]; then
 		add_note "${entry}" "Pre-flight render skipped: could not retrieve the repository file tree."
 		continue
 	fi
@@ -87,21 +84,15 @@ jq '.' extensions-batch.json
 # The render harness exits non-zero when no render was executed at all
 # (e.g. every entry failed at clone or dependency install); results.json is
 # still written, so keep going and report per-entry outcomes.
-REQUIRE_DIGEST=false IMAGE="${IMAGE}" bash "${TEST_SCRIPTS_DIR}/prepare-image.sh"
+IMAGE="${IMAGE}" bash "${TEST_SCRIPTS_DIR}/prepare-image.sh"
 QUARTO_CHANNEL="${QUARTO_CHANNEL}" bash "${TEST_SCRIPTS_DIR}/clone-extensions.sh"
-QUARTO_CHANNEL="${QUARTO_CHANNEL}" RENDER_CONCURRENCY=1 bash "${TEST_SCRIPTS_DIR}/render-extensions.sh" ||
+QUARTO_CHANNEL="${QUARTO_CHANNEL}" RENDER_CONCURRENCY=2 bash "${TEST_SCRIPTS_DIR}/render-extensions.sh" ||
 	echo "::warning::Render harness exited non-zero; reporting per-entry results."
 
 run_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}"
 failed=0
 
-while IFS= read -r result; do
-	id=$(echo "${result}" | jq -r '.id')
-	status=$(echo "${result}" | jq -r '.status')
-	stage=$(echo "${result}" | jq -r '.stage // ""')
-	failure_reason=$(echo "${result}" | jq -r '.failure_reason // ""')
-	quarto_version=$(echo "${result}" | jq -r '.quarto_version')
-	log_path=$(echo "${result}" | jq -r '.log')
+while IFS=$'\t' read -r id status stage failure_reason quarto_version log_path; do
 	entry="${batch_entry_for_repo[${id}]:-${id}}"
 
 	case "${status}" in
@@ -124,10 +115,14 @@ while IFS= read -r result; do
 			message+=$'\n\n<details><summary>Log excerpt (stderr)</summary>\n\n```\n'"${log_tail}"$'\n```\n\n</details>'
 		fi
 		message+=$'\n'"Full logs: \`preflight-render-logs\` artefact on the [workflow run](${run_url})."
-		add_error "${entry}" "${message}"
+		if [[ "${BLOCKING}" == "true" ]]; then
+			add_error "${entry}" "${message}"
+		else
+			add_note "${entry}" "${message} (Advisory: this does not block the submission.)"
+		fi
 		;;
 	esac
-done < <(jq -c '.[]' results.json)
+done < <(jq -r '.[] | [.id, .status, .stage // "", .failure_reason // "", .quarto_version, .log] | @tsv' results.json)
 
 write_check_outputs
 

--- a/.github/scripts/check-extensions/preflight-render.sh
+++ b/.github/scripts/check-extensions/preflight-render.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-flight render of extensions added in a submission PR.
+# Reuses the test-extensions harness; results are reported via step outputs
+# (picked up by the summary job and sticky PR comment) and are never
+# committed anywhere. Logs are uploaded as workflow artefacts only.
+# Inputs (env): DIFF (base64-encoded added CSV lines), CSV_FILE,
+#               GITHUB_WORKSPACE, GITHUB_OUTPUT, GITHUB_TOKEN
+# Inputs (env, optional): IMAGE (default ghcr.io/mcanouil/quarto-extensions:release),
+#               QUARTO_CHANNEL (default release), MAX_PREFLIGHT_ENTRIES (default 5),
+#               BLOCKING (default false)
+# Outputs (GITHUB_OUTPUT): errors, notes (JSON arrays of {line, message})
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_SCRIPTS_DIR="${SCRIPT_DIR}/../test-extensions"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+# shellcheck source=../test-extensions/retry.sh
+source "${TEST_SCRIPTS_DIR}/retry.sh"
+# shellcheck source=../test-extensions/classify-extension.sh
+source "${TEST_SCRIPTS_DIR}/classify-extension.sh"
+
+IMAGE="${IMAGE:-ghcr.io/mcanouil/quarto-extensions:release}"
+QUARTO_CHANNEL="${QUARTO_CHANNEL:-release}"
+MAX_PREFLIGHT_ENTRIES="${MAX_PREFLIGHT_ENTRIES:-5}"
+BLOCKING="${BLOCKING:-false}"
+
+mapfile -t entries < <(read_diff_entries)
+
+if ((${#entries[@]} == 0)); then
+	write_check_outputs
+	exit 0
+fi
+
+if ((${#entries[@]} > MAX_PREFLIGHT_ENTRIES)); then
+	echo "::notice::${#entries[@]} entries added; pre-flight render is limited to ${MAX_PREFLIGHT_ENTRIES}. Skipping."
+	add_note "${entries[0]}" "Pre-flight render skipped: ${#entries[@]} entries added (limit ${MAX_PREFLIGHT_ENTRIES})."
+	write_check_outputs
+	exit 0
+fi
+
+# Classify each valid entry into a renderable batch entry.
+batch_file=$(mktemp)
+trap 'rm -f "${batch_file}"' EXIT
+declare -A batch_entry_for_repo
+
+for entry in "${entries[@]}"; do
+	if [[ ! "${entry}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(/[A-Za-z0-9_./-]+)?$ ]] || [[ "${entry}" == *".."* ]]; then
+		add_note "${entry}" "Pre-flight render skipped: entry format not recognised."
+		continue
+	fi
+	repo=$(echo "${entry}" | cut -d'/' -f1-2)
+	subdir=$(echo "${entry}" | cut -d'/' -f3- -s)
+	subdir="${subdir%/}"
+
+	if ! tree=$(retry 3 2 gh api "repos/${repo}/git/trees/HEAD?recursive=1" --jq '.tree[]? | .path' 2>/dev/null) ||
+		[[ -z "${tree}" ]]; then
+		add_note "${entry}" "Pre-flight render skipped: could not retrieve the repository file tree."
+		continue
+	fi
+
+	if entry_json=$(printf '%s\n' "${tree}" | classify_extension_tree "${subdir}"); then
+		jq -cn --arg id "${repo}" --argjson e "${entry_json}" '{id: $id} + $e' >>"${batch_file}"
+		batch_entry_for_repo["${repo}"]="${entry}"
+	else
+		add_note "${entry}" "Pre-flight render skipped: no renderable content found (no \`_quarto.yml\` project or standalone \`.qmd\` files)."
+	fi
+done
+
+if [[ ! -s "${batch_file}" ]]; then
+	write_check_outputs
+	exit 0
+fi
+jq -sc '.' "${batch_file}" >extensions-batch.json
+echo "Pre-flight batch:"
+jq '.' extensions-batch.json
+
+# Render via the shared harness (hardened containers, no publication).
+# The render harness exits non-zero when no render was executed at all
+# (e.g. every entry failed at clone or dependency install); results.json is
+# still written, so keep going and report per-entry outcomes.
+REQUIRE_DIGEST=false IMAGE="${IMAGE}" bash "${TEST_SCRIPTS_DIR}/prepare-image.sh"
+QUARTO_CHANNEL="${QUARTO_CHANNEL}" bash "${TEST_SCRIPTS_DIR}/clone-extensions.sh"
+QUARTO_CHANNEL="${QUARTO_CHANNEL}" RENDER_CONCURRENCY=1 bash "${TEST_SCRIPTS_DIR}/render-extensions.sh" ||
+	echo "::warning::Render harness exited non-zero; reporting per-entry results."
+
+run_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}"
+failed=0
+
+while IFS= read -r result; do
+	id=$(echo "${result}" | jq -r '.id')
+	status=$(echo "${result}" | jq -r '.status')
+	stage=$(echo "${result}" | jq -r '.stage // ""')
+	failure_reason=$(echo "${result}" | jq -r '.failure_reason // ""')
+	quarto_version=$(echo "${result}" | jq -r '.quarto_version')
+	log_path=$(echo "${result}" | jq -r '.log')
+	entry="${batch_entry_for_repo[${id}]:-${id}}"
+
+	case "${status}" in
+	pass)
+		add_note "${entry}" "Pre-flight render passed with Quarto ${quarto_version} (${QUARTO_CHANNEL})."
+		;;
+	skip)
+		add_note "${entry}" "Pre-flight render skipped: repository is not publicly accessible."
+		;;
+	*)
+		failed=$((failed + 1))
+		log_tail=""
+		if [[ -f "${log_path}/stderr.log" ]]; then
+			log_tail=$(tail -c 4096 "${log_path}/stderr.log" | tail -n 20 | head -c 1500)
+			# Backtick fences in the log would break the fenced block in the PR comment.
+			log_tail="${log_tail//\`\`\`/~~~}"
+		fi
+		message="Pre-flight render failed with Quarto ${quarto_version} (${QUARTO_CHANNEL}) at stage \`${stage:-unknown}\`${failure_reason:+ (${failure_reason})}."
+		if [[ -n "${log_tail}" ]]; then
+			message+=$'\n\n<details><summary>Log excerpt (stderr)</summary>\n\n```\n'"${log_tail}"$'\n```\n\n</details>'
+		fi
+		message+=$'\n'"Full logs: \`preflight-render-logs\` artefact on the [workflow run](${run_url})."
+		add_error "${entry}" "${message}"
+		;;
+	esac
+done < <(jq -c '.[]' results.json)
+
+write_check_outputs
+
+if [[ "${BLOCKING}" == "true" ]] && ((failed > 0)); then
+	echo "::error::Pre-flight render failed for ${failed} extension(s)."
+	exit 1
+fi
+if ((failed > 0)); then
+	echo "::warning::Pre-flight render failed for ${failed} extension(s) (advisory)."
+fi

--- a/.github/scripts/check-extensions/preflight-render.sh
+++ b/.github/scripts/check-extensions/preflight-render.sh
@@ -54,6 +54,13 @@ for entry in "${entries[@]}"; do
 	subdir=$(echo "${entry}" | cut -d'/' -f3- -s)
 	subdir="${subdir%/}"
 
+	# One render per repository: a second entry for the same repo (different
+	# subdir) would clash with the first in the id-keyed results.
+	if [[ -n "${batch_entry_for_repo[${repo}]:-}" ]]; then
+		add_note "${entry}" "Pre-flight render skipped: repository already rendered for entry \`${batch_entry_for_repo[${repo}]}\` in this pull request."
+		continue
+	fi
+
 	if ! tree=$(retry 3 2 gh api "repos/${repo}/git/trees/HEAD?recursive=1" --jq '.tree[]? | .path' 2>/dev/null) ||
 		[[ -z "${tree}" ]]; then
 		add_note "${entry}" "Pre-flight render skipped: could not retrieve the repository file tree."

--- a/.github/scripts/test-extensions/build-matrix.sh
+++ b/.github/scripts/test-extensions/build-matrix.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=retry.sh
 source "${SCRIPT_DIR}/retry.sh"
+# shellcheck source=classify-extension.sh
+source "${SCRIPT_DIR}/classify-extension.sh"
 
 if [[ ! "${DEBUG}" =~ ^(true|false)$ ]]; then
   echo "::error::Invalid debug value: '${DEBUG}'. Expected 'true' or 'false'."
@@ -93,36 +95,6 @@ while IFS=$'\t' read -r idx id branch; do
 done < <(echo "${phase_b_candidates}" | jq -r 'to_entries[] | "\(.key)\t\(.value.id)\t\(.value.default_branch)"')
 wait
 
-find_best_project_path() {
-  local best_path="" best_depth=999
-  while IFS= read -r qpath; do
-    local dir
-    dir=$(dirname "${qpath}")
-    if [[ "${dir}" =~ (^|/)tests(/|$) ]] || [[ "${dir}" =~ (^|/)examples(/|$) ]]; then
-      continue
-    fi
-    if [[ "${dir}" == "." ]]; then
-      echo "."
-      return
-    fi
-    if [[ "${dir}" == "docs" ]] && [[ "${best_depth}" -gt 1 ]]; then
-      best_path="docs"
-      best_depth=1
-      continue
-    fi
-    local depth slashes
-    slashes="${dir//[!\/]/}"
-    depth=$(( ${#slashes} + 1 ))
-    if [[ "${depth}" -lt "${best_depth}" ]]; then
-      best_path="${dir}"
-      best_depth="${depth}"
-    fi
-  done
-  if [[ -n "${best_path}" ]]; then
-    echo "${best_path}"
-  fi
-}
-
 mapfile -t candidate_ids < <(echo "${phase_b_candidates}" | jq -r '.[].id')
 
 for ((idx = 0; idx < candidate_count; idx++)); do
@@ -141,33 +113,9 @@ for ((idx = 0; idx < candidate_count; idx++)); do
     continue
   fi
 
-  full_tree=$(cat "${trees_dir}/${idx}.tree")
-
-  # Check for _quarto.yml/_quarto.yaml (project), excluding _extensions/
-  project_files=$(echo "${full_tree}" | grep -E '(^|/)_quarto\.ya?ml$' | grep -vE '(^|/)_extensions/' || true)
-
-  if [[ -n "${project_files}" ]]; then
-    best_path=$(echo "${project_files}" | find_best_project_path)
-    if [[ -n "${best_path}" ]]; then
-      jq -cn --arg id "${id}" --arg pp "${best_path}" \
-        '{id: $id, type: "project", project_path: $pp}' >>"${phase_b_entries_file}"
-      continue
-    fi
-  fi
-
-  # Fallback: check for standalone .qmd files (document)
-  qmd_files=$(echo "${full_tree}" | grep -E '\.qmd$' || true)
-
-  if [[ -n "${qmd_files}" ]]; then
-    doc_files=$(echo "${qmd_files}" | jq -Rsc '
-      split("\n")[:-1]
-      | map(select(test("(^|/)(_extensions|tests|examples)/") | not))
-    ')
-    if [[ "$(echo "${doc_files}" | jq 'length')" -gt 0 ]]; then
-      jq -cn --arg id "${id}" --argjson files "${doc_files}" \
-        '{id: $id, type: "document", qmd_files: $files}' >>"${phase_b_entries_file}"
-      continue
-    fi
+  if entry_json=$(classify_extension_tree "" <"${trees_dir}/${idx}.tree"); then
+    jq -cn --arg id "${id}" --argjson e "${entry_json}" '{id: $id} + $e' >>"${phase_b_entries_file}"
+    continue
   fi
 
   jq -cn --arg id "${id}" '$id' >>"${skipped_file}"

--- a/.github/scripts/test-extensions/classify-extension.sh
+++ b/.github/scripts/test-extensions/classify-extension.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Shared classification of a repository tree into a renderable entry.
+# Source this file; do not execute it directly.
+# Used by build-matrix.sh (monthly tests) and preflight-render.sh (PR checks).
+
+# Pick the best _quarto.yml project path from a list of project file paths
+# on stdin: prefer repo root, then docs/, then the shallowest path outside
+# tests/ and examples/. Prints nothing when no suitable path exists.
+find_best_project_path() {
+	local best_path="" best_depth=999
+	while IFS= read -r qpath; do
+		local dir
+		dir=$(dirname "${qpath}")
+		if [[ "${dir}" =~ (^|/)tests(/|$) ]] || [[ "${dir}" =~ (^|/)examples(/|$) ]]; then
+			continue
+		fi
+		if [[ "${dir}" == "." ]]; then
+			echo "."
+			return
+		fi
+		if [[ "${dir}" == "docs" ]] && [[ "${best_depth}" -gt 1 ]]; then
+			best_path="docs"
+			best_depth=1
+			continue
+		fi
+		local depth slashes
+		slashes="${dir//[!\/]/}"
+		depth=$((${#slashes} + 1))
+		if [[ "${depth}" -lt "${best_depth}" ]]; then
+			best_path="${dir}"
+			best_depth="${depth}"
+		fi
+	done
+	if [[ -n "${best_path}" ]]; then
+		echo "${best_path}"
+	fi
+}
+
+# Classify a repository tree (paths on stdin, one per line) into a renderable
+# entry. $1 is an optional literal path prefix (CSV subdir) to scope to; the
+# emitted project_path/qmd_files stay relative to the repository root.
+# Prints {type: "project", project_path} or {type: "document", qmd_files};
+# returns 1 when no renderable content is found.
+classify_extension_tree() {
+	local prefix="${1:-}"
+	local tree
+	tree=$(cat)
+
+	if [[ -n "${prefix}" ]]; then
+		tree=$(printf '%s\n' "${tree}" | awk -v p="${prefix}/" 'index($0, p) == 1 { print substr($0, length(p) + 1) }')
+	fi
+
+	# Check for _quarto.yml/_quarto.yaml (project), excluding _extensions/
+	local project_files
+	project_files=$(printf '%s\n' "${tree}" | grep -E '(^|/)_quarto\.ya?ml$' | grep -vE '(^|/)_extensions/' || true)
+
+	if [[ -n "${project_files}" ]]; then
+		local best_path
+		best_path=$(printf '%s\n' "${project_files}" | find_best_project_path)
+		if [[ -n "${best_path}" ]]; then
+			if [[ -n "${prefix}" ]]; then
+				if [[ "${best_path}" == "." ]]; then
+					best_path="${prefix}"
+				else
+					best_path="${prefix}/${best_path}"
+				fi
+			fi
+			jq -cn --arg pp "${best_path}" '{type: "project", project_path: $pp}'
+			return 0
+		fi
+	fi
+
+	# Fallback: check for standalone .qmd files (document)
+	local qmd_files
+	qmd_files=$(printf '%s\n' "${tree}" | grep -E '\.qmd$' || true)
+
+	if [[ -n "${qmd_files}" ]]; then
+		local doc_files
+		doc_files=$(printf '%s\n' "${qmd_files}" | jq -Rsc --arg pfx "${prefix}" '
+			split("\n")[:-1]
+			| map(select(test("(^|/)(_extensions|tests|examples)/") | not))
+			| map(if $pfx != "" then "\($pfx)/\(.)" else . end)
+		')
+		if [[ "$(echo "${doc_files}" | jq 'length')" -gt 0 ]]; then
+			jq -cn --argjson files "${doc_files}" '{type: "document", qmd_files: $files}'
+			return 0
+		fi
+	fi
+
+	return 1
+}

--- a/.github/scripts/test-extensions/deps-install.sh
+++ b/.github/scripts/test-extensions/deps-install.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install extension dependencies inside the render container.
+# Executed via stdin by render-extensions.sh (docker run ... bash < deps-install.sh).
+# Inputs (env): EXT_ID, LOG_DIR
+# Inputs (cwd): render_dir contents (lock files, qmd files)
+
+detect_engines() {
+	local engines=""
+	if [[ -f _quarto.yml ]] || [[ -f _quarto.yaml ]]; then
+		engines=$(quarto inspect . 2>/dev/null | jq -r '.engines[]?' 2>/dev/null) || engines=""
+	fi
+	if [[ -z "${engines}" ]]; then
+		while IFS= read -r -d '' qmd; do
+			local file_engines
+			file_engines=$(quarto inspect "${qmd}" 2>/dev/null | jq -r '.engines[]?' 2>/dev/null) || true
+			if [[ -n "${file_engines}" ]]; then
+				engines=$(printf '%s\n%s' "${engines}" "${file_engines}")
+			fi
+		done < <(find . -name '*.qmd' -not -path './_extensions/*' -print0 2>/dev/null)
+		engines=$(echo "${engines}" | sort -u | sed '/^$/d')
+	fi
+	echo "${engines}"
+}
+
+engines=$(detect_engines)
+
+# Auto-detect R dependencies when no renv.lock is present
+if [[ ! -f renv.lock ]]; then
+	if echo "${engines}" | grep -qx "knitr"; then
+		echo "Auto-detecting R dependencies for ${EXT_ID} (knitr engine, no renv.lock)." >>"${LOG_DIR}/stdout.log"
+		Rscript -e '
+      ppm <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", "https://cloud.r-project.org")
+      if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv", repos = ppm)
+      deps <- unique(renv::dependencies(quiet = TRUE)[["Package"]])
+      deps <- setdiff(deps, rownames(installed.packages()))
+      if (length(deps) > 0L) {
+        cat("Installing R packages:", paste(deps, collapse = ", "), "\n")
+        install.packages(deps, repos = ppm)
+      } else {
+        cat("No additional R packages to install.\n")
+      }
+    ' >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+			echo "Auto-detect R dependency install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+			exit 1
+		}
+	fi
+fi
+
+# Auto-detect Python dependencies when no uv.lock/requirements.txt is present
+if [[ ! -f uv.lock ]] && [[ ! -f requirements.txt ]]; then
+	if echo "${engines}" | grep -qx "jupyter"; then
+		has_python=false
+		while IFS= read -r -d '' qmd; do
+			if grep -qP '^\s*```\{python' "${qmd}" 2>/dev/null; then
+				has_python=true
+				break
+			fi
+		done < <(find . -name '*.qmd' -not -path './_extensions/*' -print0)
+
+		if [[ "${has_python}" == "true" ]]; then
+			echo "Auto-detecting Python dependencies for ${EXT_ID} (jupyter engine, no lock file)." >>"${LOG_DIR}/stdout.log"
+			uv venv >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+				echo "uv venv failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+				exit 1
+			}
+			# shellcheck disable=SC1091 # created at runtime by uv venv
+			source .venv/bin/activate
+
+			deps=$(find . -name '*.qmd' -not -path './_extensions/*' -print0 |
+				xargs -0 python3 -c '
+import sys, ast, re
+
+stdlib = set(sys.stdlib_module_names) if hasattr(sys, "stdlib_module_names") else set()
+imports = set()
+chunk_re = re.compile(r"^\s*```\{python[^}]*\}\s*$")
+end_re = re.compile(r"^\s*```\s*$")
+
+for path in sys.argv[1:]:
+    in_chunk = False
+    lines = []
+    with open(path) as f:
+        for line in f:
+            if not in_chunk and chunk_re.match(line):
+                in_chunk = True
+                lines = []
+            elif in_chunk and end_re.match(line):
+                in_chunk = False
+                source = "\n".join(lines)
+                try:
+                    tree = ast.parse(source)
+                    for node in ast.walk(tree):
+                        if isinstance(node, ast.Import):
+                            for alias in node.names:
+                                imports.add(alias.name.split(".")[0])
+                        elif isinstance(node, ast.ImportFrom):
+                            if node.module:
+                                imports.add(node.module.split(".")[0])
+                except SyntaxError:
+                    pass
+                lines = []
+            elif in_chunk:
+                lines.append(line.rstrip())
+
+third_party = sorted(imports - stdlib - {"__future__"})
+for pkg in third_party:
+    print(pkg)
+' 2>/dev/null) || deps=""
+
+			if [[ -n "${deps}" ]]; then
+				echo "Installing Python packages: ${deps//$'\n'/, }" >>"${LOG_DIR}/stdout.log"
+				echo "${deps}" | xargs uv pip install -- \
+					>>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+					echo "Auto-detect Python dependency install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+					exit 1
+				}
+			else
+				echo "No additional Python packages to install." >>"${LOG_DIR}/stdout.log"
+			fi
+		fi
+	fi
+fi
+
+# Auto-detect Julia dependencies when no Project.toml is present
+if [[ ! -f Project.toml ]] && [[ ! -f JuliaProject.toml ]]; then
+	if echo "${engines}" | grep -qx "jupyter"; then
+		has_julia=false
+		while IFS= read -r -d '' qmd; do
+			if grep -qP '^\s*```\{julia' "${qmd}" 2>/dev/null; then
+				has_julia=true
+				break
+			fi
+		done < <(find . -name '*.qmd' -not -path './_extensions/*' -print0)
+
+		if [[ "${has_julia}" == "true" ]]; then
+			echo "Auto-detecting Julia dependencies for ${EXT_ID} (jupyter engine, no Project.toml)." >>"${LOG_DIR}/stdout.log"
+
+			deps=$(
+				find . -name '*.qmd' -not -path './_extensions/*' -print0 |
+					xargs -0 grep -hP '^\s*(using|import)\s+' 2>/dev/null |
+					sed -E 's/^\s*(using|import)\s+//' |
+					sed -E 's/:.*//' |
+					tr ',' '\n' |
+					sed -E 's/^\s+//; s/\s+$//; s/[.].*//' |
+					grep -E '^[A-Za-z][A-Za-z0-9_]*$' |
+					sort -u |
+					grep -vxF -e Base -e Core -e Main -e Pkg \
+						-e InteractiveUtils -e LinearAlgebra -e Random \
+						-e Statistics -e Dates -e Printf -e Markdown \
+						-e Test -e Logging -e REPL -e Sockets -e UUIDs \
+						-e Distributed -e SharedArrays -e SparseArrays \
+						-e DelimitedFiles -e Serialization -e Libdl \
+						-e Mmap -e Profile -e FileWatching -e Unicode \
+						-e TOML -e Downloads -e LazyArtifacts -e Artifacts \
+						-e SHA -e NetworkOptions -e StyledStrings
+			) || deps=""
+
+			if [[ -n "${deps}" ]]; then
+				echo "Installing Julia packages: ${deps//$'\n'/, }" >>"${LOG_DIR}/stdout.log"
+				pkg_list=$(echo "${deps}" | sed "s/.*/\"&\"/" | paste -sd ',' -)
+				julia --project=. -e 'using Pkg; Pkg.add(['"${pkg_list}"'])' \
+					>>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+					echo "Auto-detect Julia dependency install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+					exit 1
+				}
+			else
+				echo "No additional Julia packages to install." >>"${LOG_DIR}/stdout.log"
+			fi
+		fi
+	fi
+fi
+
+if [[ -f renv.lock ]]; then
+	echo "Installing R dependencies from renv.lock for ${EXT_ID}." >>"${LOG_DIR}/stdout.log"
+	Rscript -e 'if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")' \
+		>>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+		echo "renv install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+		exit 1
+	}
+	Rscript -e 'renv::restore()' \
+		>>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+		echo "renv restore failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+		exit 1
+	}
+fi
+if [[ -f uv.lock ]] || [[ -f requirements.txt ]]; then
+	echo "Installing Python dependencies for ${EXT_ID}." >>"${LOG_DIR}/stdout.log"
+	uv venv >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+		echo "uv venv failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+		exit 1
+	}
+	# shellcheck disable=SC1091 # created at runtime by uv venv
+	source .venv/bin/activate
+	if [[ -f uv.lock ]]; then
+		uv sync >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+			echo "uv sync failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+			exit 1
+		}
+	elif [[ -f requirements.txt ]]; then
+		uv pip install -r requirements.txt >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+			echo "uv pip install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+			exit 1
+		}
+	fi
+fi
+if [[ -f Project.toml ]] || [[ -f JuliaProject.toml ]]; then
+	echo "Installing Julia dependencies from Project.toml for ${EXT_ID}." >>"${LOG_DIR}/stdout.log"
+	julia --project=. -e 'using Pkg; Pkg.instantiate()' \
+		>>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+		echo "Julia Pkg.instantiate failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+		exit 1
+	}
+fi

--- a/.github/scripts/test-extensions/prepare-image.sh
+++ b/.github/scripts/test-extensions/prepare-image.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prepare the local 'render-image' used by clone-extensions.sh and
+# render-extensions.sh: pull the test image and apply a job-level overlay
+# (TinyTeX ownership fix so tlmgr works when the container runs as host UID:GID).
+# Inputs (env): IMAGE (digest-pinned ref, or tag when REQUIRE_DIGEST=false),
+#               REQUIRE_DIGEST (default true)
+# Outputs: docker image tagged 'render-image'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=retry.sh
+source "${SCRIPT_DIR}/retry.sh"
+
+REQUIRE_DIGEST="${REQUIRE_DIGEST:-true}"
+
+if [[ "${REQUIRE_DIGEST}" == "true" ]]; then
+	if [[ ! "${IMAGE}" =~ @sha256:[0-9a-f]{64}$ ]]; then
+		echo "::error::Image reference '${IMAGE}' is not a valid digest-pinned reference."
+		exit 1
+	fi
+	if ! retry 3 5 docker pull "${IMAGE}"; then
+		echo "::error::Failed to pull image '${IMAGE}'."
+		exit 1
+	fi
+	image_ref="${IMAGE}"
+else
+	if ! retry 3 5 docker pull "${IMAGE}"; then
+		echo "::error::Failed to pull image '${IMAGE}'."
+		exit 1
+	fi
+	image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "${IMAGE}" 2>/dev/null || true)
+	if [[ -z "${image_ref}" ]]; then
+		echo "::error::Failed to resolve digest for image '${IMAGE}'."
+		exit 1
+	fi
+	if [[ ! "${image_ref}" =~ @sha256:[0-9a-f]{64}$ ]]; then
+		echo "::error::Resolved image reference '${image_ref}' is not a valid digest-pinned reference."
+		exit 1
+	fi
+fi
+
+docker tag "${image_ref}" render-image
+
+# Pick one reachable CTAN mirror per job instead of negotiating per extension.
+CTAN_MIRRORS=(
+	"https://ctan.math.utah.edu/ctan/tex-archive/systems/texlive/tlnet"
+	"https://ctan.math.illinois.edu/systems/texlive/tlnet"
+	"https://mirrors.rit.edu/CTAN/systems/texlive/tlnet"
+	"https://mirror.ctan.org/systems/texlive/tlnet"
+)
+CTAN_MIRROR=""
+for mirror in "${CTAN_MIRRORS[@]}"; do
+	if retry 2 2 curl -fsI --max-time 10 "${mirror}/" >/dev/null 2>&1; then
+		CTAN_MIRROR="${mirror}"
+		break
+	fi
+	echo "CTAN mirror ${mirror} unreachable, trying next..."
+done
+if [[ -n "${CTAN_MIRROR}" ]]; then
+	echo "Using CTAN mirror: ${CTAN_MIRROR}"
+else
+	echo "::warning::No CTAN mirror reachable. tlmgr keeps the repository baked into the image."
+fi
+
+# Job-level overlay: point tlmgr at the chosen mirror (as root, before the
+# ownership change), then fix TinyTeX ownership so tlmgr works when the
+# container runs as host UID:GID.
+docker build -t render-image \
+	--build-arg HOST_UID="$(id -u)" \
+	--build-arg HOST_GID="$(id -g)" \
+	--build-arg CTAN_MIRROR="${CTAN_MIRROR}" \
+	- <<'OVERLAY'
+FROM render-image
+ARG HOST_UID
+ARG HOST_GID
+ARG CTAN_MIRROR
+USER root
+RUN if [ -d /opt/tinytex ] && [ -n "${CTAN_MIRROR}" ] && command -v tlmgr >/dev/null 2>&1; then \
+    tlmgr repository set "${CTAN_MIRROR}" && tlmgr update --self; \
+    fi
+RUN if [ -d /opt/tinytex ]; then chown -R "${HOST_UID}:${HOST_GID}" /opt/tinytex; fi
+OVERLAY
+
+echo "Prepared render-image from ${image_ref}."

--- a/.github/scripts/test-extensions/prepare-image.sh
+++ b/.github/scripts/test-extensions/prepare-image.sh
@@ -4,38 +4,24 @@ set -euo pipefail
 # Prepare the local 'render-image' used by clone-extensions.sh and
 # render-extensions.sh: pull the test image and apply a job-level overlay
 # (TinyTeX ownership fix so tlmgr works when the container runs as host UID:GID).
-# Inputs (env): IMAGE (digest-pinned ref, or tag when REQUIRE_DIGEST=false),
-#               REQUIRE_DIGEST (default true)
+# Inputs (env): IMAGE (digest-pinned ref, or a tag that gets resolved to one)
 # Outputs: docker image tagged 'render-image'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=retry.sh
 source "${SCRIPT_DIR}/retry.sh"
 
-REQUIRE_DIGEST="${REQUIRE_DIGEST:-true}"
+if ! retry 3 5 docker pull "${IMAGE}"; then
+	echo "::error::Failed to pull image '${IMAGE}'."
+	exit 1
+fi
 
-if [[ "${REQUIRE_DIGEST}" == "true" ]]; then
-	if [[ ! "${IMAGE}" =~ @sha256:[0-9a-f]{64}$ ]]; then
-		echo "::error::Image reference '${IMAGE}' is not a valid digest-pinned reference."
-		exit 1
-	fi
-	if ! retry 3 5 docker pull "${IMAGE}"; then
-		echo "::error::Failed to pull image '${IMAGE}'."
-		exit 1
-	fi
+if [[ "${IMAGE}" =~ @sha256:[0-9a-f]{64}$ ]]; then
 	image_ref="${IMAGE}"
 else
-	if ! retry 3 5 docker pull "${IMAGE}"; then
-		echo "::error::Failed to pull image '${IMAGE}'."
-		exit 1
-	fi
 	image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "${IMAGE}" 2>/dev/null || true)
-	if [[ -z "${image_ref}" ]]; then
-		echo "::error::Failed to resolve digest for image '${IMAGE}'."
-		exit 1
-	fi
 	if [[ ! "${image_ref}" =~ @sha256:[0-9a-f]{64}$ ]]; then
-		echo "::error::Resolved image reference '${image_ref}' is not a valid digest-pinned reference."
+		echo "::error::Failed to resolve a digest-pinned reference for image '${IMAGE}' (got '${image_ref}')."
 		exit 1
 	fi
 fi

--- a/.github/scripts/test-extensions/publish-results.sh
+++ b/.github/scripts/test-extensions/publish-results.sh
@@ -70,7 +70,9 @@ jq -c --arg d "${today}" --slurpfile cur "${current_run_file}" '
               quarto_channel: $e.quarto_channel,
               status: $e.status,
               log: $e.log,
-              date: $d
+              date: $d,
+              stage: (($e.stage // "") | tostring),
+              failure_reason: (($e.failure_reason // "") | tostring)
             }]
         )
     )
@@ -79,7 +81,7 @@ jq -c --arg d "${today}" --slurpfile cur "${current_run_file}" '
 
 skipped_count=$(echo "${skipped_json}" | jq 'length')
 
-read -r run_total run_pass run_fail run_skip < <(
+read -r run_total run_pass run_fail run_skip run_fail_deps run_fail_render run_fail_other < <(
   jq -r '
     . as $all
     | ($all | [.[].id] | unique | length) as $run_total
@@ -87,7 +89,12 @@ read -r run_total run_pass run_fail run_skip < <(
     | ([$groups[] | select(all(.status == "pass"))] | length) as $run_pass
     | ([$groups[] | select(any(.status == "fail"))] | length) as $run_fail
     | ([$groups[] | select(all(.status == "skip"))] | length) as $run_skip
-    | [$run_total, $run_pass, $run_fail, $run_skip] | @tsv
+    | ([$groups[] | select(any(.status == "fail"))
+        | ([.[] | select(.status == "fail") | .stage // ""] | first)]) as $fail_stages
+    | ($fail_stages | map(select(. == "deps")) | length) as $run_fail_deps
+    | ($fail_stages | map(select(. == "render")) | length) as $run_fail_render
+    | ($run_fail - $run_fail_deps - $run_fail_render) as $run_fail_other
+    | [$run_total, $run_pass, $run_fail, $run_skip, $run_fail_deps, $run_fail_render, $run_fail_other] | @tsv
   ' "${current_run_file}"
 )
 
@@ -101,15 +108,18 @@ release_version=$(jq -r '[.[] | select(.quarto_channel == "release") | .quarto_v
 prerelease_version=$(jq -r '[.[] | select(.quarto_channel == "prerelease") | .quarto_version] | first // "n/a"' "${current_run_file}")
 repo_url="https://github.com/${GITHUB_REPOSITORY}/tree/quarto-tests"
 results_table=$(jq -r --arg repo_url "${repo_url}" '
+  def stage_note: if . != null and . != "" then " (\(.))" else "" end;
   sort_by(.id) | group_by(.id) | .[] |
   {
     id: .[0].id,
     release_status: ([.[] | select(.quarto_channel == "release") | .status] | first // "n/a"),
     release_version: ([.[] | select(.quarto_channel == "release") | .quarto_version] | first // ""),
+    release_stage: ([.[] | select(.quarto_channel == "release") | .stage] | first // ""),
     prerelease_status: ([.[] | select(.quarto_channel == "prerelease") | .status] | first // "n/a"),
-    prerelease_version: ([.[] | select(.quarto_channel == "prerelease") | .quarto_version] | first // "")
+    prerelease_version: ([.[] | select(.quarto_channel == "prerelease") | .quarto_version] | first // ""),
+    prerelease_stage: ([.[] | select(.quarto_channel == "prerelease") | .stage] | first // "")
   } |
-  "| \(.id) | \(if .release_status == "pass" then "[✅](\($repo_url)/logs/\(.id)/release/\(.release_version))" elif .release_status == "fail" then "[❌](\($repo_url)/logs/\(.id)/release/\(.release_version))" elif .release_status == "skip" then "⏭️" else "—" end) | \(if .prerelease_status == "pass" then "[✅](\($repo_url)/logs/\(.id)/prerelease/\(.prerelease_version))" elif .prerelease_status == "fail" then "[❌](\($repo_url)/logs/\(.id)/prerelease/\(.prerelease_version))" elif .prerelease_status == "skip" then "⏭️" else "—" end) |"
+  "| \(.id) | \(if .release_status == "pass" then "[✅](\($repo_url)/logs/\(.id)/release/\(.release_version))" elif .release_status == "fail" then "[❌](\($repo_url)/logs/\(.id)/release/\(.release_version))\(.release_stage | stage_note)" elif .release_status == "skip" then "⏭️" else "—" end) | \(if .prerelease_status == "pass" then "[✅](\($repo_url)/logs/\(.id)/prerelease/\(.prerelease_version))" elif .prerelease_status == "fail" then "[❌](\($repo_url)/logs/\(.id)/prerelease/\(.prerelease_version))\(.prerelease_stage | stage_note)" elif .prerelease_status == "skip" then "⏭️" else "—" end) |"
 ' "${current_run_file}")
 skipped_list=$(echo "${skipped_json}" | jq -r '.[] | "- \(.)"')
 
@@ -118,7 +128,7 @@ skipped_list=$(echo "${skipped_json}" | jq -r '.[] | "- \(.)"')
   echo ""
   echo "- **Extensions tested:** ${run_total}"
   echo "- **Pass:** ${run_pass}"
-  echo "- **Fail:** ${run_fail}"
+  echo "- **Fail:** ${run_fail} (dependencies: ${run_fail_deps}, render: ${run_fail_render}, other: ${run_fail_other})"
   echo "- **Skipped (repository not publicly accessible):** ${run_skip}"
   echo "- **Skipped (no renderable content found):** ${skipped_count}"
   echo ""

--- a/.github/scripts/test-extensions/publish-results.sh
+++ b/.github/scripts/test-extensions/publish-results.sh
@@ -94,7 +94,7 @@ read -r run_total run_pass run_fail run_skip run_fail_deps run_fail_render run_f
         | if any(. == "deps") then "deps" elif any(. == "render") then "render" else "other" end]) as $fail_stages
     | ($fail_stages | map(select(. == "deps")) | length) as $run_fail_deps
     | ($fail_stages | map(select(. == "render")) | length) as $run_fail_render
-    | ($run_fail - $run_fail_deps - $run_fail_render) as $run_fail_other
+    | ($fail_stages | map(select(. == "other")) | length) as $run_fail_other
     | [$run_total, $run_pass, $run_fail, $run_skip, $run_fail_deps, $run_fail_render, $run_fail_other] | @tsv
   ' "${current_run_file}"
 )

--- a/.github/scripts/test-extensions/publish-results.sh
+++ b/.github/scripts/test-extensions/publish-results.sh
@@ -90,7 +90,8 @@ read -r run_total run_pass run_fail run_skip run_fail_deps run_fail_render run_f
     | ([$groups[] | select(any(.status == "fail"))] | length) as $run_fail
     | ([$groups[] | select(all(.status == "skip"))] | length) as $run_skip
     | ([$groups[] | select(any(.status == "fail"))
-        | ([.[] | select(.status == "fail") | .stage // ""] | first)]) as $fail_stages
+        | [.[] | select(.status == "fail") | .stage // ""]
+        | if any(. == "deps") then "deps" elif any(. == "render") then "render" else "other" end]) as $fail_stages
     | ($fail_stages | map(select(. == "deps")) | length) as $run_fail_deps
     | ($fail_stages | map(select(. == "render")) | length) as $run_fail_render
     | ($run_fail - $run_fail_deps - $run_fail_render) as $run_fail_other

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -200,10 +200,16 @@ render_shard() {
 	done
 }
 
+shard_pids=()
 for ((w = 0; w < RENDER_CONCURRENCY; w++)); do
 	render_shard "${w}" &
+	shard_pids+=("$!")
 done
-wait
+for ((w = 0; w < RENDER_CONCURRENCY; w++)); do
+	if ! wait "${shard_pids[w]}"; then
+		echo "::warning::Render shard ${w} exited non-zero; its remaining extensions were not rendered."
+	fi
+done
 
 shopt -s nullglob
 result_files=("${results_dir}"/*.json)

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Render extensions for the test-extensions workflow.
-# Inputs (env): QUARTO_CHANNEL
+# Inputs (env): QUARTO_CHANNEL, RENDER_CONCURRENCY (default 2)
 # Inputs (files): clone-manifest.json, quarto-version.txt
 # Outputs (files): results.json
 
@@ -10,29 +10,32 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=docker-config.sh
 source "${SCRIPT_DIR}/docker-config.sh"
 
-results_file=$(mktemp)
-trap 'rm -f "${results_file}"' EXIT
+RENDER_CONCURRENCY="${RENDER_CONCURRENCY:-2}"
+if [[ ! "${RENDER_CONCURRENCY}" =~ ^[1-9][0-9]*$ ]]; then
+	echo "::error::Invalid RENDER_CONCURRENCY value '${RENDER_CONCURRENCY}'. Expected a positive integer."
+	exit 1
+fi
+
+results_dir=$(mktemp -d)
+trap 'rm -rf "${results_dir}"' EXIT
 quarto_version=$(cat quarto-version.txt)
 echo "Quarto version: ${quarto_version} (${QUARTO_CHANNEL})"
 
-render_count=0
 ext_count=$(jq 'length' clone-manifest.json)
 
-# Fix TinyTeX ownership so tlmgr works when container runs as host UID:GID
-docker build -t render-image \
-	--build-arg HOST_UID="$(id -u)" \
-	--build-arg HOST_GID="$(id -g)" \
-	- <<'TINYTEX_FIX'
-FROM render-image
-ARG HOST_UID
-ARG HOST_GID
-USER root
-RUN if [ -d /opt/tinytex ]; then chown -R "${HOST_UID}:${HOST_GID}" /opt/tinytex; fi
-TINYTEX_FIX
+# Package caches shared across extensions within this job only (never
+# persisted across jobs or runs, so cache poisoning is bounded to one batch).
+# The R library is per shard: concurrent install.packages into one library
+# is racy; renv, uv, and Julia caches are concurrency-safe.
+cache_root="${GITHUB_WORKSPACE}/cache"
+install -d -m 700 "${cache_root}/renv" "${cache_root}/uv" "${cache_root}/julia"
+for ((w = 0; w < RENDER_CONCURRENCY; w++)); do
+	install -d -m 700 "${cache_root}/r-lib-${w}"
+done
 
 docker_run_render() {
-	local run_timeout="$1" workdir="$2" log_dir="$3" render_dir="$4"
-	shift 4
+	local run_timeout="$1" workdir="$2" log_dir="$3" render_dir="$4" shard="$5"
+	shift 5
 	timeout --kill-after=30 "${run_timeout}" docker run --rm -i \
 		--user "${DOCKER_USER}" \
 		"${DOCKER_SECURITY_OPTS[@]}" \
@@ -46,6 +49,11 @@ docker_run_render() {
 		-e XDG_CACHE_HOME="${workdir}/.cache" \
 		-e TEXMFVAR="/tmp/texmf-var" \
 		-e TEXMFCONFIG="/tmp/texmf-config" \
+		-e RENV_PATHS_CACHE="/cache/renv" \
+		-e UV_CACHE_DIR="/cache/uv" \
+		-e JULIA_DEPOT_PATH="/cache/julia:" \
+		-e R_LIBS_USER="/cache/r-lib-${shard}" \
+		-v "${cache_root}:/cache" \
 		-v "${workdir}:${workdir}" \
 		-v "${log_dir}:${log_dir}" \
 		-w "${render_dir}" \
@@ -55,6 +63,7 @@ docker_run_render() {
 
 render_extension() {
 	local i="$1"
+	local shard="${2:-0}"
 
 	local id ext_type status workdir render_dir log_dir log_path ext
 	IFS=$'\t' read -r id ext_type status workdir render_dir log_dir log_path < <(
@@ -67,6 +76,16 @@ render_extension() {
 		return
 	fi
 
+	# Failure-stage taxonomy: clone|policy|deps|render (empty on pass)
+	local stage="" failure_reason=""
+	if [[ "${status}" == "fail" ]]; then
+		stage="clone"
+		failure_reason="clone failed"
+	elif [[ "${status}" == "skip" ]]; then
+		stage="clone"
+		failure_reason="repository-inaccessible"
+	fi
+
 	if [[ "${status}" == "pass" ]]; then
 		printf '%s\n' "${ext}" >"${workdir}/ext-meta.json"
 
@@ -76,6 +95,8 @@ render_extension() {
 				>>"${log_dir}/stdout.log" 2>>"${log_dir}/stderr.log"; then
 				echo "::warning::Dependency policy check failed for ${id}."
 				status="fail"
+				stage="policy"
+				failure_reason="dependency source policy violation"
 			fi
 		fi
 
@@ -91,335 +112,54 @@ render_extension() {
 				dep_sources+=("auto-detect")
 			fi
 			echo "Dependency install phase for ${id}: ${dep_sources[*]}" >>"${log_dir}/stdout.log"
+			run_dep_install() {
+				docker_run_render 600 "${workdir}" "${log_dir}" "${render_dir}" "${shard}" \
+					-e EXT_ID="${id}" \
+					-e LOG_DIR="${log_dir}" \
+					<"${SCRIPT_DIR}/deps-install.sh"
+			}
 			dep_rc=0
-			docker_run_render 600 "${workdir}" "${log_dir}" "${render_dir}" \
-				-e EXT_ID="${id}" \
-				-e LOG_DIR="${log_dir}" \
-				<<'DEPS_SCRIPT' || dep_rc=$?
-set -euo pipefail
-
-detect_engines() {
-  local engines=""
-  if [[ -f _quarto.yml ]] || [[ -f _quarto.yaml ]]; then
-    engines=$(quarto inspect . 2>/dev/null | jq -r '.engines[]?' 2>/dev/null) || engines=""
-  fi
-  if [[ -z "${engines}" ]]; then
-    while IFS= read -r -d '' qmd; do
-      local file_engines
-      file_engines=$(quarto inspect "${qmd}" 2>/dev/null | jq -r '.engines[]?' 2>/dev/null) || true
-      if [[ -n "${file_engines}" ]]; then
-        engines=$(printf '%s\n%s' "${engines}" "${file_engines}")
-      fi
-    done < <(find . -name '*.qmd' -not -path './_extensions/*' -print0 2>/dev/null)
-    engines=$(echo "${engines}" | sort -u | sed '/^$/d')
-  fi
-  echo "${engines}"
-}
-
-engines=$(detect_engines)
-
-# Auto-detect R dependencies when no renv.lock is present
-if [[ ! -f renv.lock ]]; then
-  if echo "${engines}" | grep -qx "knitr"; then
-    echo "Auto-detecting R dependencies for ${EXT_ID} (knitr engine, no renv.lock)." >>"${LOG_DIR}/stdout.log"
-    Rscript -e '
-      ppm <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", "https://cloud.r-project.org")
-      if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv", repos = ppm)
-      deps <- unique(renv::dependencies(quiet = TRUE)[["Package"]])
-      deps <- setdiff(deps, rownames(installed.packages()))
-      if (length(deps) > 0L) {
-        cat("Installing R packages:", paste(deps, collapse = ", "), "\n")
-        install.packages(deps, repos = ppm)
-      } else {
-        cat("No additional R packages to install.\n")
-      }
-    ' >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-      echo "Auto-detect R dependency install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-      exit 1
-    }
-  fi
-fi
-
-# Auto-detect Python dependencies when no uv.lock/requirements.txt is present
-if [[ ! -f uv.lock ]] && [[ ! -f requirements.txt ]]; then
-  if echo "${engines}" | grep -qx "jupyter"; then
-    has_python=false
-    while IFS= read -r -d '' qmd; do
-      if grep -qP '^\s*```\{python' "${qmd}" 2>/dev/null; then
-        has_python=true
-        break
-      fi
-    done < <(find . -name '*.qmd' -not -path './_extensions/*' -print0)
-
-    if [[ "${has_python}" == "true" ]]; then
-      echo "Auto-detecting Python dependencies for ${EXT_ID} (jupyter engine, no lock file)." >>"${LOG_DIR}/stdout.log"
-      uv venv >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-        echo "uv venv failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-        exit 1
-      }
-      source .venv/bin/activate
-
-      deps=$(find . -name '*.qmd' -not -path './_extensions/*' -print0 \
-        | xargs -0 python3 -c '
-import sys, ast, re
-
-stdlib = set(sys.stdlib_module_names) if hasattr(sys, "stdlib_module_names") else set()
-imports = set()
-chunk_re = re.compile(r"^\s*```\{python[^}]*\}\s*$")
-end_re = re.compile(r"^\s*```\s*$")
-
-for path in sys.argv[1:]:
-    in_chunk = False
-    lines = []
-    with open(path) as f:
-        for line in f:
-            if not in_chunk and chunk_re.match(line):
-                in_chunk = True
-                lines = []
-            elif in_chunk and end_re.match(line):
-                in_chunk = False
-                source = "\n".join(lines)
-                try:
-                    tree = ast.parse(source)
-                    for node in ast.walk(tree):
-                        if isinstance(node, ast.Import):
-                            for alias in node.names:
-                                imports.add(alias.name.split(".")[0])
-                        elif isinstance(node, ast.ImportFrom):
-                            if node.module:
-                                imports.add(node.module.split(".")[0])
-                except SyntaxError:
-                    pass
-                lines = []
-            elif in_chunk:
-                lines.append(line.rstrip())
-
-third_party = sorted(imports - stdlib - {"__future__"})
-for pkg in third_party:
-    print(pkg)
-' 2>/dev/null) || deps=""
-
-      if [[ -n "${deps}" ]]; then
-        echo "Installing Python packages: ${deps//$'\n'/, }" >>"${LOG_DIR}/stdout.log"
-        echo "${deps}" | xargs uv pip install -- \
-          >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-          echo "Auto-detect Python dependency install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-          exit 1
-        }
-      else
-        echo "No additional Python packages to install." >>"${LOG_DIR}/stdout.log"
-      fi
-    fi
-  fi
-fi
-
-# Auto-detect Julia dependencies when no Project.toml is present
-if [[ ! -f Project.toml ]] && [[ ! -f JuliaProject.toml ]]; then
-  if echo "${engines}" | grep -qx "jupyter"; then
-    has_julia=false
-    while IFS= read -r -d '' qmd; do
-      if grep -qP '^\s*```\{julia' "${qmd}" 2>/dev/null; then
-        has_julia=true
-        break
-      fi
-    done < <(find . -name '*.qmd' -not -path './_extensions/*' -print0)
-
-    if [[ "${has_julia}" == "true" ]]; then
-      echo "Auto-detecting Julia dependencies for ${EXT_ID} (jupyter engine, no Project.toml)." >>"${LOG_DIR}/stdout.log"
-
-      deps=$(find . -name '*.qmd' -not -path './_extensions/*' -print0 \
-        | xargs -0 grep -hP '^\s*(using|import)\s+' 2>/dev/null \
-        | sed -E 's/^\s*(using|import)\s+//' \
-        | sed -E 's/:.*//' \
-        | tr ',' '\n' \
-        | sed -E 's/^\s+//; s/\s+$//; s/[.].*//' \
-        | grep -E '^[A-Za-z][A-Za-z0-9_]*$' \
-        | sort -u \
-        | grep -vxF -e Base -e Core -e Main -e Pkg \
-            -e InteractiveUtils -e LinearAlgebra -e Random \
-            -e Statistics -e Dates -e Printf -e Markdown \
-            -e Test -e Logging -e REPL -e Sockets -e UUIDs \
-            -e Distributed -e SharedArrays -e SparseArrays \
-            -e DelimitedFiles -e Serialization -e Libdl \
-            -e Mmap -e Profile -e FileWatching -e Unicode \
-            -e TOML -e Downloads -e LazyArtifacts -e Artifacts \
-            -e SHA -e NetworkOptions -e StyledStrings \
-      ) || deps=""
-
-      if [[ -n "${deps}" ]]; then
-        echo "Installing Julia packages: ${deps//$'\n'/, }" >>"${LOG_DIR}/stdout.log"
-        pkg_list=$(echo "${deps}" | sed "s/.*/\"&\"/" | paste -sd ',' -)
-        julia --project=. -e 'using Pkg; Pkg.add(['"${pkg_list}"'])' \
-          >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-          echo "Auto-detect Julia dependency install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-          exit 1
-        }
-      else
-        echo "No additional Julia packages to install." >>"${LOG_DIR}/stdout.log"
-      fi
-    fi
-  fi
-fi
-
-if [[ -f renv.lock ]]; then
-  echo "Installing R dependencies from renv.lock for ${EXT_ID}." >>"${LOG_DIR}/stdout.log"
-  Rscript -e 'if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")' \
-    >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-    echo "renv install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-    exit 1
-  }
-  Rscript -e 'renv::restore()' \
-    >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-    echo "renv restore failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-    exit 1
-  }
-fi
-if [[ -f uv.lock ]] || [[ -f requirements.txt ]]; then
-  echo "Installing Python dependencies for ${EXT_ID}." >>"${LOG_DIR}/stdout.log"
-  uv venv >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-    echo "uv venv failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-    exit 1
-  }
-  source .venv/bin/activate
-  if [[ -f uv.lock ]]; then
-    uv sync >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-      echo "uv sync failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-      exit 1
-    }
-  elif [[ -f requirements.txt ]]; then
-    uv pip install -r requirements.txt >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-      echo "uv pip install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-      exit 1
-    }
-  fi
-fi
-if [[ -f Project.toml ]] || [[ -f JuliaProject.toml ]]; then
-  echo "Installing Julia dependencies from Project.toml for ${EXT_ID}." >>"${LOG_DIR}/stdout.log"
-  julia --project=. -e 'using Pkg; Pkg.instantiate()' \
-    >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-    echo "Julia Pkg.instantiate failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-    exit 1
-  }
-fi
-DEPS_SCRIPT
+			run_dep_install || dep_rc=$?
+			# Retry once to absorb network flakes; a timeout already ate 600s, do not re-run it.
+			if [[ "${dep_rc}" -ne 0 ]] && [[ "${dep_rc}" -ne 124 ]]; then
+				echo "Dependency install failed (exit ${dep_rc}) for ${id}; retrying once." >>"${log_dir}/stderr.log"
+				dep_rc=0
+				run_dep_install || dep_rc=$?
+			fi
 			if [[ "${dep_rc}" -eq 124 ]]; then
 				echo "Dependency install timed out (exit 124) for ${id}." >>"${log_dir}/stderr.log"
 				echo "::warning::Dependency install timed out for ${id}."
 				status="fail"
+				stage="deps"
+				failure_reason="timeout"
 			elif [[ "${dep_rc}" -ne 0 ]]; then
 				echo "Dependency install failed (exit ${dep_rc}) for ${id}." >>"${log_dir}/stderr.log"
 				echo "::warning::Dependency install failed (exit ${dep_rc}) for ${id}."
 				status="fail"
+				stage="deps"
+				failure_reason="exit ${dep_rc}"
 			fi
 		fi
 
 		# Phase B: Render
 		if [[ "${status}" == "pass" ]]; then
-			render_count=$((render_count + 1))
-			docker_run_render 300 "${workdir}" "${log_dir}" "${render_dir}" \
+			touch "${results_dir}/${i}.rendered"
+			render_rc=0
+			docker_run_render 300 "${workdir}" "${log_dir}" "${render_dir}" "${shard}" \
 				-e EXT_TYPE="${ext_type}" \
 				-e EXT_ID="${id}" \
 				-e WORKDIR="${workdir}" \
 				-e LOG_DIR="${log_dir}" \
-				<<'RENDER_SCRIPT' || status="fail"
-set -euo pipefail
-
-# Activate local venv if created during dependency install.
-# Preserve access to the image-level venv site-packages so pre-installed
-# packages (jupyter, shinylive, pyyaml, etc.) remain importable.
-IMAGE_VENV="/home/vscode/.venv"
-if [[ -f .venv/bin/activate ]]; then
-  image_sp=""
-  for sp in "${IMAGE_VENV}"/lib/python*/site-packages; do
-    if [[ -d "${sp}" ]]; then image_sp="${sp}"; break; fi
-  done
-  source .venv/bin/activate
-  if [[ -n "${image_sp}" ]]; then
-    export PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${image_sp}"
-  fi
-fi
-
-if command -v tlmgr >/dev/null 2>&1; then
-  CTAN_MIRRORS=(
-    "https://ctan.math.utah.edu/ctan/tex-archive/systems/texlive/tlnet"
-    "https://ctan.math.illinois.edu/systems/texlive/tlnet"
-    "https://mirrors.rit.edu/CTAN/systems/texlive/tlnet"
-    "https://mirror.ctan.org/systems/texlive/tlnet"
-  )
-  tlmgr_ok=false
-  for mirror in "${CTAN_MIRRORS[@]}"; do
-    if timeout 30 tlmgr repository set "${mirror}" >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" \
-      && timeout 60 tlmgr update --self >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log"; then
-      echo "Using CTAN mirror: ${mirror}" >>"${LOG_DIR}/stdout.log"
-      tlmgr_ok=true
-      break
-    fi
-    echo "CTAN mirror ${mirror} failed, trying next..." >>"${LOG_DIR}/stderr.log"
-  done
-  if [[ "${tlmgr_ok}" == "false" ]]; then
-    echo "All CTAN mirrors failed. LaTeX packages may not install." >>"${LOG_DIR}/stderr.log"
-  fi
-fi
-
-quarto_render() {
-  local log_name="$1"
-  shift
-  if ! quarto render "$@" --log "${WORKDIR}/${log_name}.log" --log-level info \
-    >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log"; then
-    echo "Render failed, retrying once..." >>"${LOG_DIR}/stderr.log"
-    quarto render "$@" --log "${WORKDIR}/${log_name}.log" --log-level info \
-      >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || return 1
-  fi
-}
-
-render_single_qmd() {
-  local qmd="$1"
-  local base
-  base="$(basename "${qmd}" .qmd)"
-  local formats
-  formats=$(quarto inspect "${qmd}" 2>/dev/null | jq -r '.formats | keys[]' 2>/dev/null) || formats=""
-  if [[ -z "${formats}" ]]; then
-    quarto_render "${base}" "${qmd}" || exit 1
-  else
-    while IFS= read -r fmt; do
-      quarto_render "${base}-${fmt}" "${qmd}" --to "${fmt}" || exit 1
-    done <<< "${formats}"
-  fi
-}
-
-# Extension dev repos keep _extensions at the repo root and symlink it into
-# example/test subprojects, where the link is typically gitignored. Recreate
-# those links so nested _quarto.yml projects resolve the extension when their
-# documents are rendered individually. Skip projects whose _quarto.yml already
-# references _extensions: they manage it themselves (e.g. a pre-render copy),
-# and a pre-created symlink would collide with that copy.
-root_ext="$(pwd)/_extensions"
-if [[ -d "${root_ext}" ]]; then
-  while IFS= read -r -d '' qy; do
-    proj_dir="$(dirname "${qy}")"
-    [[ "${proj_dir}" == "." ]] && continue
-    [[ -e "${proj_dir}/_extensions" ]] && continue
-    grep -q '_extensions' "${qy}" && continue
-    ln -s "${root_ext}" "${proj_dir}/_extensions"
-  done < <(find . \( -name _quarto.yml -o -name _quarto.yaml \) -not -path './_extensions/*' -print0)
-fi
-
-if [[ -f _quarto.yml ]] || [[ -f _quarto.yaml ]]; then
-  quarto_render "project" || exit 1
-elif [[ "${EXT_TYPE}" == "document" ]]; then
-  qmd_files=$(jq -r '.qmd_files[]?' "${WORKDIR}/ext-meta.json")
-  while IFS= read -r qmd; do
-    if [[ "${qmd}" == /* ]] || [[ "${qmd}" == *".."* ]]; then continue; fi
-    if [[ -f "${qmd}" ]]; then
-      render_single_qmd "${qmd}"
-    fi
-  done <<< "${qmd_files}"
-else
-  while IFS= read -r -d '' qmd; do
-    render_single_qmd "${qmd}"
-  done < <(find . -name '*.qmd' -not -path './_extensions/*' -print0)
-fi
-RENDER_SCRIPT
+				<"${SCRIPT_DIR}/render-inner.sh" || render_rc=$?
+			if [[ "${render_rc}" -ne 0 ]]; then
+				status="fail"
+				stage="render"
+				if [[ "${render_rc}" -eq 124 ]]; then
+					failure_reason="timeout"
+				else
+					failure_reason="exit ${render_rc}"
+				fi
+			fi
 		fi
 	fi
 
@@ -443,19 +183,38 @@ RENDER_SCRIPT
 		--arg l "${log_path}" \
 		--arg qv "${quarto_version}" \
 		--arg qc "${QUARTO_CHANNEL}" \
-		'{id: $id, type: $t, status: $s, log: $l, quarto_version: $qv, quarto_channel: $qc}' \
-		>>"${results_file}"
+		--arg st "${stage}" \
+		--arg fr "${failure_reason}" \
+		'{id: $id, type: $t, status: $s, log: $l, quarto_version: $qv, quarto_channel: $qc, stage: $st, failure_reason: $fr}' \
+		>"${results_dir}/${i}.json"
 }
 
-for ((i = 0; i < ext_count; i++)); do
-	render_extension "${i}"
-done
+# Static interleaved sharding: shard w renders indices i where
+# i % RENDER_CONCURRENCY == w. Results and render markers are per-index
+# files because subshell variable updates do not propagate to the parent.
+render_shard() {
+	local shard="$1"
+	local i
+	for ((i = shard; i < ext_count; i += RENDER_CONCURRENCY)); do
+		render_extension "${i}" "${shard}"
+	done
+}
 
-if [[ -s "${results_file}" ]]; then
-	jq -sc '.' "${results_file}" >results.json
+for ((w = 0; w < RENDER_CONCURRENCY; w++)); do
+	render_shard "${w}" &
+done
+wait
+
+shopt -s nullglob
+result_files=("${results_dir}"/*.json)
+if ((${#result_files[@]} > 0)); then
+	jq -sc '.' "${result_files[@]}" >results.json
 else
 	echo '[]' >results.json
 fi
+render_markers=("${results_dir}"/*.rendered)
+render_count=${#render_markers[@]}
+shopt -u nullglob
 
 if [[ "${ext_count}" -gt 0 ]] && [[ "${render_count}" -eq 0 ]]; then
 	echo "::error::No quarto render was executed for ${ext_count} extensions."
@@ -463,5 +222,7 @@ if [[ "${ext_count}" -gt 0 ]] && [[ "${render_count}" -eq 0 ]]; then
 fi
 
 echo "Rendered ${render_count}/${ext_count} extensions."
+echo "Shared cache size: $(du -sh "${cache_root}" 2>/dev/null | cut -f1)"
+df -h /
 echo "Results:"
 jq '.' results.json

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -143,7 +143,6 @@ render_extension() {
 
 		# Phase B: Render
 		if [[ "${status}" == "pass" ]]; then
-			touch "${results_dir}/${i}.rendered"
 			render_rc=0
 			docker_run_render 300 "${workdir}" "${log_dir}" "${render_dir}" "${shard}" \
 				-e EXT_TYPE="${ext_type}" \
@@ -190,8 +189,8 @@ render_extension() {
 }
 
 # Static interleaved sharding: shard w renders indices i where
-# i % RENDER_CONCURRENCY == w. Results and render markers are per-index
-# files because subshell variable updates do not propagate to the parent.
+# i % RENDER_CONCURRENCY == w. Results are per-index files because subshell
+# variable updates do not propagate to the parent.
 render_shard() {
 	local shard="$1"
 	local i
@@ -213,14 +212,15 @@ done
 
 shopt -s nullglob
 result_files=("${results_dir}"/*.json)
+shopt -u nullglob
 if ((${#result_files[@]} > 0)); then
 	jq -sc '.' "${result_files[@]}" >results.json
 else
 	echo '[]' >results.json
 fi
-render_markers=("${results_dir}"/*.rendered)
-render_count=${#render_markers[@]}
-shopt -u nullglob
+# A render was executed exactly when the extension passed or failed at the
+# render stage (earlier stages never reach quarto render).
+render_count=$(jq '[.[] | select(.status == "pass" or .stage == "render")] | length' results.json)
 
 if [[ "${ext_count}" -gt 0 ]] && [[ "${render_count}" -eq 0 ]]; then
 	echo "::error::No quarto render was executed for ${ext_count} extensions."

--- a/.github/scripts/test-extensions/render-inner.sh
+++ b/.github/scripts/test-extensions/render-inner.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Render an extension inside the render container.
+# Executed via stdin by render-extensions.sh (docker run ... bash < render-inner.sh).
+# Inputs (env): EXT_TYPE, EXT_ID, WORKDIR, LOG_DIR
+# Inputs (cwd): render_dir contents; ${WORKDIR}/ext-meta.json
+
+# Activate local venv if created during dependency install.
+# Preserve access to the image-level venv site-packages so pre-installed
+# packages (jupyter, shinylive, pyyaml, etc.) remain importable.
+IMAGE_VENV="/home/vscode/.venv"
+if [[ -f .venv/bin/activate ]]; then
+	image_sp=""
+	for sp in "${IMAGE_VENV}"/lib/python*/site-packages; do
+		if [[ -d "${sp}" ]]; then
+			image_sp="${sp}"
+			break
+		fi
+	done
+	# shellcheck disable=SC1091 # created at runtime by uv venv
+	source .venv/bin/activate
+	if [[ -n "${image_sp}" ]]; then
+		export PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${image_sp}"
+	fi
+fi
+
+quarto_render() {
+	local log_name="$1"
+	shift
+	if ! quarto render "$@" --log "${WORKDIR}/${log_name}.log" --log-level info \
+		>>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log"; then
+		echo "Render failed, retrying once..." >>"${LOG_DIR}/stderr.log"
+		quarto render "$@" --log "${WORKDIR}/${log_name}.log" --log-level info \
+			>>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || return 1
+	fi
+}
+
+render_single_qmd() {
+	local qmd="$1"
+	local base
+	base="$(basename "${qmd}" .qmd)"
+	local formats
+	formats=$(quarto inspect "${qmd}" 2>/dev/null | jq -r '.formats | keys[]' 2>/dev/null) || formats=""
+	if [[ -z "${formats}" ]]; then
+		quarto_render "${base}" "${qmd}" || exit 1
+	else
+		while IFS= read -r fmt; do
+			quarto_render "${base}-${fmt}" "${qmd}" --to "${fmt}" || exit 1
+		done <<<"${formats}"
+	fi
+}
+
+# Extension dev repos keep _extensions at the repo root and symlink it into
+# example/test subprojects, where the link is typically gitignored. Recreate
+# those links so nested _quarto.yml projects resolve the extension when their
+# documents are rendered individually. Skip projects whose _quarto.yml already
+# references _extensions: they manage it themselves (e.g. a pre-render copy),
+# and a pre-created symlink would collide with that copy.
+root_ext="$(pwd)/_extensions"
+if [[ -d "${root_ext}" ]]; then
+	while IFS= read -r -d '' qy; do
+		proj_dir="$(dirname "${qy}")"
+		[[ "${proj_dir}" == "." ]] && continue
+		[[ -e "${proj_dir}/_extensions" ]] && continue
+		grep -q '_extensions' "${qy}" && continue
+		ln -s "${root_ext}" "${proj_dir}/_extensions"
+	done < <(find . \( -name _quarto.yml -o -name _quarto.yaml \) -not -path './_extensions/*' -print0)
+fi
+
+if [[ -f _quarto.yml ]] || [[ -f _quarto.yaml ]]; then
+	quarto_render "project" || exit 1
+elif [[ "${EXT_TYPE}" == "document" ]]; then
+	qmd_files=$(jq -r '.qmd_files[]?' "${WORKDIR}/ext-meta.json")
+	while IFS= read -r qmd; do
+		if [[ "${qmd}" == /* ]] || [[ "${qmd}" == *".."* ]]; then continue; fi
+		if [[ -f "${qmd}" ]]; then
+			render_single_qmd "${qmd}"
+		fi
+	done <<<"${qmd_files}"
+else
+	while IFS= read -r -d '' qmd; do
+		render_single_qmd "${qmd}"
+	done < <(find . -name '*.qmd' -not -path './_extensions/*' -print0)
+fi

--- a/.github/workflows/check-extensions.yml
+++ b/.github/workflows/check-extensions.yml
@@ -306,24 +306,23 @@ jobs:
   check-render:
     runs-on: ubuntu-latest
     needs: check-submission
+    if: needs.check-submission.outputs.submission == 'true'
     timeout-minutes: 30
     permissions:
       contents: read
       packages: read
     outputs:
-      errors: ${{ steps.store-results.outputs.errors }}
-      notes: ${{ steps.store-results.outputs.notes }}
+      errors: ${{ steps.check.outputs.errors || '[]' }}
+      notes: ${{ steps.check.outputs.notes || '[]' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 2
       - name: Log in to ghcr.io
-        if: needs.check-submission.outputs.submission == 'true'
         shell: bash
         run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
       - name: Pre-flight render
-        if: needs.check-submission.outputs.submission == 'true'
         id: check
         env:
           DIFF: ${{ needs.check-submission.outputs.diff }}
@@ -332,36 +331,14 @@ jobs:
           QUARTO_CHANNEL: release
         shell: bash
         run: bash .github/scripts/check-extensions/preflight-render.sh
-      - name: Store results
-        if: always() && needs.check-submission.outputs.submission == 'true'
-        id: store-results
-        env:
-          errors: ${{ steps.check.outputs.errors }}
-          notes: ${{ steps.check.outputs.notes }}
-        shell: bash
-        run: |
-          if [[ -z "${errors}" ]]; then
-            errors="[]"
-          fi
-          if [[ -z "${notes}" ]]; then
-            notes="[]"
-          fi
-          echo "errors=${errors}" >> ${GITHUB_OUTPUT}
-          echo "notes=${notes}" >> ${GITHUB_OUTPUT}
       - name: Upload render logs
-        if: always() && needs.check-submission.outputs.submission == 'true'
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: preflight-render-logs
           path: logs/
           retention-days: 7
           if-no-files-found: ignore
-      - name: End of check
-        if: needs.check-submission.outputs.submission == 'false'
-        shell: bash
-        run: |
-          echo "No changes to ${CSV_FILE} found"
-          exit 0
 
   summary:
     runs-on: ubuntu-latest
@@ -402,7 +379,6 @@ jobs:
           RENDER_RESULT: ${{ needs.check-render.result }}
           RENDER_ERRORS: ${{ needs.check-render.outputs.errors }}
           RENDER_NOTES: ${{ needs.check-render.outputs.notes }}
-          RENDER_BLOCKING: ${{ vars.CHECK_RENDER_BLOCKING || 'false' }}
         shell: bash
         run: |
           echo "## Extension Check Summary" >> "${GITHUB_STEP_SUMMARY}"
@@ -412,28 +388,16 @@ jobs:
 
           declare -A mention_owners
 
-          # Pre-flight render failures block only when CHECK_RENDER_BLOCKING is
-          # true; otherwise they are advisory (own section, PR stays mergeable).
-          RENDER_BLOCKING_ERRORS="[]"
-          RENDER_ADVISORY_ERRORS="[]"
-          if [[ "${RENDER_BLOCKING}" == "true" ]]; then
-            RENDER_BLOCKING_ERRORS="${RENDER_ERRORS:-[]}"
-          else
-            RENDER_ADVISORY_ERRORS="${RENDER_ERRORS:-[]}"
-          fi
-
+          # The pre-flight render script emits blocking failures as errors and
+          # advisory ones as notes, and only exits non-zero when blocking.
           errors_found=false
           if [[ "${DUPLICATE_RESULT}" == "failure" || \
                 "${TOPICS_RESULT}" == "failure" || \
                 "${DESCRIPTION_RESULT}" == "failure" || \
                 "${RELEASE_RESULT}" == "failure" || \
-                "${REDIRECTION_RESULT}" == "failure" ]]; then
-            errors_found=true
-          fi
-          if [[ "${STRUCTURE_RESULT}" == "failure" ]]; then
-            errors_found=true
-          fi
-          if [[ "${RENDER_BLOCKING}" == "true" && "${RENDER_RESULT}" == "failure" ]]; then
+                "${REDIRECTION_RESULT}" == "failure" || \
+                "${STRUCTURE_RESULT}" == "failure" || \
+                "${RENDER_RESULT}" == "failure" ]]; then
             errors_found=true
           fi
 
@@ -447,7 +411,7 @@ jobs:
             "${RELEASE_ERRORS}" \
             "${REDIRECTION_ERRORS}" \
             "${STRUCTURE_ERRORS}" \
-            "${RENDER_BLOCKING_ERRORS}"; do
+            "${RENDER_ERRORS}"; do
               if [[ "${errors_json}" != "[]" && "${errors_json}" != "" ]]; then
                 while read -r error_obj; do
                   line=$(echo "${error_obj}" | jq -r ".line")
@@ -478,36 +442,6 @@ jobs:
             echo "✅ All checks passed successfully!" >> "${GITHUB_STEP_SUMMARY}"
             echo "" >> "${GITHUB_STEP_SUMMARY}"
             echo "🔍 [View workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})" >> "${GITHUB_STEP_SUMMARY}"
-          fi
-
-          if [[ "${RENDER_ADVISORY_ERRORS}" != "[]" && "${RENDER_ADVISORY_ERRORS}" != "" ]]; then
-            declare -A file_line_render
-
-            while read -r error_obj; do
-              line=$(echo "${error_obj}" | jq -r ".line")
-              message=$(echo "${error_obj}" | jq -r ".message")
-              if [[ -z "${file_line_render[${line}]}" ]]; then
-                file_line_render["${line}"]="- ⚠️ ${message}"
-              else
-                file_line_render["${line}"]+=$'\n- ⚠️ '"${message}"
-              fi
-            done < <(echo "${RENDER_ADVISORY_ERRORS}" | jq -c ".[]")
-
-            echo "---" >> "${GITHUB_STEP_SUMMARY}"
-            echo "" >> "${GITHUB_STEP_SUMMARY}"
-            echo "### Pre-flight render (advisory)" >> "${GITHUB_STEP_SUMMARY}"
-            echo "" >> "${GITHUB_STEP_SUMMARY}"
-            echo "These renders failed but do not block this submission." >> "${GITHUB_STEP_SUMMARY}"
-            echo "" >> "${GITHUB_STEP_SUMMARY}"
-
-            for line_number in $(echo "${!file_line_render[@]}" | tr ' ' '\n' | sort -n); do
-              entry=$(sed -n "${line_number}p" ${CSV_FILE})
-              mention_owners["${entry%%/*}"]=1
-              echo "#### Line [${line_number}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${NUMBER}/files#diff-${CSV_FILE_ENCODED}L${line_number}): [\`${entry}\`](${GITHUB_SERVER_URL}/${entry})" >> "${GITHUB_STEP_SUMMARY}"
-              echo "" >> "${GITHUB_STEP_SUMMARY}"
-              echo -e "${file_line_render[${line_number}]}" >> "${GITHUB_STEP_SUMMARY}"
-              echo "" >> "${GITHUB_STEP_SUMMARY}"
-            done
           fi
 
           ALL_NOTES=$(jq -cn \

--- a/.github/workflows/check-extensions.yml
+++ b/.github/workflows/check-extensions.yml
@@ -303,6 +303,66 @@ jobs:
           echo "No changes to ${CSV_FILE} found"
           exit 0
 
+  check-render:
+    runs-on: ubuntu-latest
+    needs: check-submission
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      errors: ${{ steps.store-results.outputs.errors }}
+      notes: ${{ steps.store-results.outputs.notes }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+      - name: Log in to ghcr.io
+        if: needs.check-submission.outputs.submission == 'true'
+        shell: bash
+        run: echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+      - name: Pre-flight render
+        if: needs.check-submission.outputs.submission == 'true'
+        id: check
+        env:
+          DIFF: ${{ needs.check-submission.outputs.diff }}
+          BLOCKING: ${{ vars.CHECK_RENDER_BLOCKING || 'false' }}
+          IMAGE: ghcr.io/${{ github.repository }}:release
+          QUARTO_CHANNEL: release
+        shell: bash
+        run: bash .github/scripts/check-extensions/preflight-render.sh
+      - name: Store results
+        if: always() && needs.check-submission.outputs.submission == 'true'
+        id: store-results
+        env:
+          errors: ${{ steps.check.outputs.errors }}
+          notes: ${{ steps.check.outputs.notes }}
+        shell: bash
+        run: |
+          if [[ -z "${errors}" ]]; then
+            errors="[]"
+          fi
+          if [[ -z "${notes}" ]]; then
+            notes="[]"
+          fi
+          echo "errors=${errors}" >> ${GITHUB_OUTPUT}
+          echo "notes=${notes}" >> ${GITHUB_OUTPUT}
+      - name: Upload render logs
+        if: always() && needs.check-submission.outputs.submission == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: preflight-render-logs
+          path: logs/
+          retention-days: 7
+          if-no-files-found: ignore
+      - name: End of check
+        if: needs.check-submission.outputs.submission == 'false'
+        shell: bash
+        run: |
+          echo "No changes to ${CSV_FILE} found"
+          exit 0
+
   summary:
     runs-on: ubuntu-latest
     needs:
@@ -314,6 +374,7 @@ jobs:
       - check-redirection
       - check-structure
       - check-wizard
+      - check-render
     if: always()
     steps:
       - name: Checkout repository
@@ -338,6 +399,10 @@ jobs:
           REDIRECTION_ERRORS: ${{ needs.check-redirection.outputs.errors }}
           STRUCTURE_ERRORS: ${{ needs.check-structure.outputs.errors }}
           WIZARD_NOTES: ${{ needs.check-wizard.outputs.notes }}
+          RENDER_RESULT: ${{ needs.check-render.result }}
+          RENDER_ERRORS: ${{ needs.check-render.outputs.errors }}
+          RENDER_NOTES: ${{ needs.check-render.outputs.notes }}
+          RENDER_BLOCKING: ${{ vars.CHECK_RENDER_BLOCKING || 'false' }}
         shell: bash
         run: |
           echo "## Extension Check Summary" >> "${GITHUB_STEP_SUMMARY}"
@@ -346,6 +411,16 @@ jobs:
           CSV_FILE_ENCODED=$(echo -n "${CSV_FILE}" | hexdump -v -e '/1 "%02x"' | sed 's/\(..\)/%\1/g')
 
           declare -A mention_owners
+
+          # Pre-flight render failures block only when CHECK_RENDER_BLOCKING is
+          # true; otherwise they are advisory (own section, PR stays mergeable).
+          RENDER_BLOCKING_ERRORS="[]"
+          RENDER_ADVISORY_ERRORS="[]"
+          if [[ "${RENDER_BLOCKING}" == "true" ]]; then
+            RENDER_BLOCKING_ERRORS="${RENDER_ERRORS:-[]}"
+          else
+            RENDER_ADVISORY_ERRORS="${RENDER_ERRORS:-[]}"
+          fi
 
           errors_found=false
           if [[ "${DUPLICATE_RESULT}" == "failure" || \
@@ -358,6 +433,9 @@ jobs:
           if [[ "${STRUCTURE_RESULT}" == "failure" ]]; then
             errors_found=true
           fi
+          if [[ "${RENDER_BLOCKING}" == "true" && "${RENDER_RESULT}" == "failure" ]]; then
+            errors_found=true
+          fi
 
           if [[ "${errors_found}" == "true" ]]; then
             declare -A file_line_errors
@@ -368,7 +446,8 @@ jobs:
             "${DESCRIPTION_ERRORS}" \
             "${RELEASE_ERRORS}" \
             "${REDIRECTION_ERRORS}" \
-            "${STRUCTURE_ERRORS}"; do
+            "${STRUCTURE_ERRORS}" \
+            "${RENDER_BLOCKING_ERRORS}"; do
               if [[ "${errors_json}" != "[]" && "${errors_json}" != "" ]]; then
                 while read -r error_obj; do
                   line=$(echo "${error_obj}" | jq -r ".line")
@@ -401,7 +480,40 @@ jobs:
             echo "🔍 [View workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})" >> "${GITHUB_STEP_SUMMARY}"
           fi
 
-          ALL_NOTES="${WIZARD_NOTES:-[]}"
+          if [[ "${RENDER_ADVISORY_ERRORS}" != "[]" && "${RENDER_ADVISORY_ERRORS}" != "" ]]; then
+            declare -A file_line_render
+
+            while read -r error_obj; do
+              line=$(echo "${error_obj}" | jq -r ".line")
+              message=$(echo "${error_obj}" | jq -r ".message")
+              if [[ -z "${file_line_render[${line}]}" ]]; then
+                file_line_render["${line}"]="- ⚠️ ${message}"
+              else
+                file_line_render["${line}"]+=$'\n- ⚠️ '"${message}"
+              fi
+            done < <(echo "${RENDER_ADVISORY_ERRORS}" | jq -c ".[]")
+
+            echo "---" >> "${GITHUB_STEP_SUMMARY}"
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+            echo "### Pre-flight render (advisory)" >> "${GITHUB_STEP_SUMMARY}"
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+            echo "These renders failed but do not block this submission." >> "${GITHUB_STEP_SUMMARY}"
+            echo "" >> "${GITHUB_STEP_SUMMARY}"
+
+            for line_number in $(echo "${!file_line_render[@]}" | tr ' ' '\n' | sort -n); do
+              entry=$(sed -n "${line_number}p" ${CSV_FILE})
+              mention_owners["${entry%%/*}"]=1
+              echo "#### Line [${line_number}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${NUMBER}/files#diff-${CSV_FILE_ENCODED}L${line_number}): [\`${entry}\`](${GITHUB_SERVER_URL}/${entry})" >> "${GITHUB_STEP_SUMMARY}"
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+              echo -e "${file_line_render[${line_number}]}" >> "${GITHUB_STEP_SUMMARY}"
+              echo "" >> "${GITHUB_STEP_SUMMARY}"
+            done
+          fi
+
+          ALL_NOTES=$(jq -cn \
+            --argjson w "${WIZARD_NOTES:-[]}" \
+            --argjson r "${RENDER_NOTES:-[]}" \
+            '$w + $r')
 
           if [[ "${ALL_NOTES}" != "[]" && "${ALL_NOTES}" != "" ]]; then
             declare -A file_line_notes

--- a/.github/workflows/check-extensions.yml
+++ b/.github/workflows/check-extensions.yml
@@ -15,7 +15,7 @@ env:
   CSV_FILE: "extensions/quarto-extensions.csv"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -74,27 +74,7 @@ jobs:
         if: needs.check-submission.outputs.submission == 'true'
         id: check
         shell: bash
-        run: |
-          error=false
-          errors_json="[]"
-          sort -f "${CSV_FILE}" | uniq -di > duplicates.txt
-          if [[ -s duplicates.txt ]]; then
-            while IFS= read -r duplicate; do
-              grep -n "${duplicate}" "${CSV_FILE}" | tail -n +2 > duplicate_lines.txt
-              while IFS= read -r line; do
-                line_number=${line%%:*}
-                error_message="Duplicate value \"${duplicate}\" found"
-                # echo "::error file=${CSV_FILE},line=${line_number},endLine=${line_number},title=Duplicate Entry::${error_message}"
-                errors_json=$(echo ${errors_json} | jq --compact-output --arg line "${line_number}" '. += [{"line": $line, "message": "Repository is duplicated."}]')
-                error=true
-              done < duplicate_lines.txt
-            done < duplicates.txt
-          fi
-          rm -f duplicates.txt duplicate_lines.txt
-          echo "errors=${errors_json}" >> ${GITHUB_OUTPUT}
-          if [[ "${error}" == "true" ]]; then
-            exit 1
-          fi
+        run: bash .github/scripts/check-extensions/check-duplicate.sh
       - name: Store errors
         if: always() && needs.check-submission.outputs.submission == 'true'
         id: store-errors
@@ -129,27 +109,7 @@ jobs:
         env:
           DIFF: ${{ needs.check-submission.outputs.diff }}
         shell: bash
-        run: |
-          echo ${DIFF} | base64 --decode > diff.patch
-          error=false
-          errors_json="[]"
-          if [[ -s diff.patch ]]; then
-            while IFS=, read -r repo; do
-              repo=$(echo "${repo}" | cut -d'/' -f1-2)
-              repo_topics=$(gh repo view --json repositoryTopics "${repo}" --jq ".repositoryTopics")
-              if [[ -z "${repo_topics}" ]]; then
-                line_number=$(grep -n "${repo}" ${CSV_FILE} | cut -d: -f1 | tail -n 1)
-                error_message="Repository \"${repo}\" is missing topics!"
-                # echo "::error file=${CSV_FILE},line=${line_number},endLine=${line_number}::${error_message}"
-                errors_json=$(echo ${errors_json} | jq --compact-output --arg line "${line_number}" '. += [{"line": $line, "message": "Repository is missing topics."}]')
-                error=true
-              fi
-            done < diff.patch
-          fi
-          echo "errors=${errors_json}" >> ${GITHUB_OUTPUT}
-          if [[ "${error}" == "true" ]]; then
-            exit 1
-          fi
+        run: bash .github/scripts/check-extensions/check-topics.sh
       - name: Store errors
         if: always() && needs.check-submission.outputs.submission == 'true'
         id: store-errors
@@ -184,27 +144,7 @@ jobs:
         env:
           DIFF: ${{ needs.check-submission.outputs.diff }}
         shell: bash
-        run: |
-          echo ${DIFF} | base64 --decode > diff.patch
-          error=false
-          errors_json="[]"
-          if [[ -s diff.patch ]]; then
-            while IFS=, read -r repo; do
-              repo=$(echo "${repo}" | cut -d'/' -f1-2)
-              repo_description=$(gh repo view --json description "${repo}" --jq ".description")
-              if [[ -z "${repo_description}" ]]; then
-                line_number=$(grep -n "${repo}" ${CSV_FILE} | cut -d: -f1 | tail -n 1)
-                error_message="Repository \"${repo}\" is missing description!"
-                # echo "::error file=${CSV_FILE},line=${line_number},endLine=${line_number}::${error_message}"
-                errors_json=$(echo ${errors_json} | jq --compact-output --arg line "${line_number}" '. += [{"line": $line, "message": "Repository is missing description."}]')
-                error=true
-              fi
-            done < diff.patch
-          fi
-          echo "errors=${errors_json}" >> ${GITHUB_OUTPUT}
-          if [[ "${error}" == "true" ]]; then
-            exit 1
-          fi
+        run: bash .github/scripts/check-extensions/check-description.sh
       - name: Store errors
         if: always() && needs.check-submission.outputs.submission == 'true'
         id: store-errors
@@ -239,27 +179,7 @@ jobs:
         env:
           DIFF: ${{ needs.check-submission.outputs.diff }}
         shell: bash
-        run: |
-          echo ${DIFF} | base64 --decode > diff.patch
-          error=false
-          errors_json="[]"
-          if [[ -s diff.patch ]]; then
-            while IFS=, read -r repo; do
-              repo=$(echo "${repo}" | cut -d'/' -f1-2)
-              repo_release=$(gh repo view --json latestRelease "${repo}" --jq ".latestRelease")
-              if [[ -z "${repo_release}" ]]; then
-                line_number=$(grep -n "${repo}" ${CSV_FILE} | cut -d: -f1 | tail -n 1)
-                error_message="Repository \"${repo}\" is missing release/tag!"
-                # echo "::error file=${CSV_FILE},line=${line_number},endLine=${line_number}::${error_message}"
-                errors_json=$(echo ${errors_json} | jq --compact-output --arg line "${line_number}" '. += [{"line": $line, "message": "Repository is missing release/tag."}]')
-                error=true
-              fi
-            done < diff.patch
-          fi
-          echo "errors=${errors_json}" >> ${GITHUB_OUTPUT}
-          if [[ "${error}" == "true" ]]; then
-            exit 1
-          fi
+        run: bash .github/scripts/check-extensions/check-release.sh
       - name: Store errors
         if: always() && needs.check-submission.outputs.submission == 'true'
         id: store-errors
@@ -291,26 +211,10 @@ jobs:
       - name: Check for redirection
         if: needs.check-submission.outputs.submission == 'true'
         id: check
+        env:
+          DIFF: ${{ needs.check-submission.outputs.diff }}
         shell: bash
-        run: |
-          error=false
-          errors_json="[]"
-          while IFS=, read -r entry; do
-            repo=$(echo "${repo}" | cut -d'/' -f1-2)
-            if curl -I -s "https://github.com/${repo}" | grep -q "HTTP/.* 30[127]"; then
-              redirection_target=$(curl -Ls -o /dev/null -w "%{url_effective}" "https://github.com/${repo}")
-              redirection_target=${redirection_target#"https://github.com/"}
-              error_message="Repository \"${repo}\" is redirected to \"${redirection_target}\"!"
-              line_number=$(grep -n "${repo}" ${CSV_FILE} | cut -d: -f1 | tail -n 1)
-              # echo "::error file=${CSV_FILE},line=${line_number},endLine=${line_number}::${error_message}"
-              errors_json=$(echo ${errors_json} | jq --compact-output --arg line "${line_number}" '. += [{"line": $line, "message": "Repository is redirected."}]')
-              error=true
-            fi
-          done < <(sort -f "${CSV_FILE}")
-          echo "errors=${errors_json}" >> ${GITHUB_OUTPUT}
-          if [[ "${error}" == "true" ]]; then
-            exit 1
-          fi
+        run: bash .github/scripts/check-extensions/check-redirection.sh
       - name: Store errors
         if: always() && needs.check-submission.outputs.submission == 'true'
         id: store-errors
@@ -345,40 +249,7 @@ jobs:
         env:
           DIFF: ${{ needs.check-submission.outputs.diff }}
         shell: bash
-        run: |
-          echo ${DIFF} | base64 --decode > diff.patch
-          error=false
-          errors_json="[]"
-          if [[ -s diff.patch ]]; then
-            while IFS=, read -r entry; do
-              repo=$(echo "${entry}" | cut -d'/' -f1-2)
-              subdir=$(echo "${entry}" | cut -d'/' -f3-)
-
-              tree=$(gh api "repos/${repo}/git/trees/HEAD?recursive=1" --jq '.tree[].path' 2>/dev/null || true)
-
-              line_number=$(grep -n "${entry}" ${CSV_FILE} | cut -d: -f1 | tail -n 1)
-
-              if [[ -z "${tree}" ]]; then
-                error_message="Could not retrieve repository file tree to verify the extension structure."
-                errors_json=$(echo ${errors_json} | jq --compact-output --arg line "${line_number}" --arg message "${error_message}" '. += [{"line": $line, "message": $message}]')
-                error=true
-                continue
-              fi
-
-              ext_prefix="${subdir:+${subdir}/}"
-
-              has_extension=$(echo "${tree}" | grep -E "^${ext_prefix}_extensions/[^/]+/_extension\.ya?ml$" | head -n 1 || true)
-              if [[ -z "${has_extension}" ]]; then
-                error_message="Repository is missing a valid Quarto extension structure (\`_extensions/<name>/_extension.yml\`)."
-                errors_json=$(echo ${errors_json} | jq --compact-output --arg line "${line_number}" --arg message "${error_message}" '. += [{"line": $line, "message": $message}]')
-                error=true
-              fi
-            done < diff.patch
-          fi
-          echo "errors=${errors_json}" >> ${GITHUB_OUTPUT}
-          if [[ "${error}" == "true" ]]; then
-            exit 1
-          fi
+        run: bash .github/scripts/check-extensions/check-structure.sh
       - name: Store errors
         if: always() && needs.check-submission.outputs.submission == 'true'
         id: store-errors
@@ -413,51 +284,7 @@ jobs:
         env:
           DIFF: ${{ needs.check-submission.outputs.diff }}
         shell: bash
-        run: |
-          echo ${DIFF} | base64 --decode > diff.patch
-          notes_json="[]"
-          if [[ -s diff.patch ]]; then
-            while IFS=, read -r entry; do
-              repo=$(echo "${entry}" | cut -d'/' -f1-2)
-              subdir=$(echo "${entry}" | cut -d'/' -f3-)
-
-              tree=$(gh api "repos/${repo}/git/trees/HEAD?recursive=1" --jq '.tree[].path' 2>/dev/null || true)
-              if [[ -z "${tree}" ]]; then
-                continue
-              fi
-
-              if [[ -n "${subdir}" ]]; then
-                ext_prefix="${subdir}/"
-              else
-                ext_prefix=""
-              fi
-
-              has_extension=$(echo "${tree}" | grep -E "^${ext_prefix}_extensions/[^/]+/_extension\.yml$" | head -n 1 || true)
-              if [[ -z "${has_extension}" ]]; then
-                continue
-              fi
-
-              ext_dir=$(dirname "${has_extension}")
-
-              has_schema=$(echo "${tree}" | grep -E "^${ext_dir}/_schema\.(yml|yaml|json)$" || true)
-              has_snippets=$(echo "${tree}" | grep -E "^${ext_dir}/_snippets\.json$" || true)
-
-              if [[ -z "${has_schema}" && -z "${has_snippets}" ]]; then
-                missing="schema (\`_schema.yml\`) and snippets (\`_snippets.json\`) files"
-              elif [[ -z "${has_schema}" ]]; then
-                missing="schema (\`_schema.yml\`) file"
-              elif [[ -z "${has_snippets}" ]]; then
-                missing="snippets (\`_snippets.json\`) file"
-              else
-                continue
-              fi
-
-              line_number=$(grep -n "${entry}" ${CSV_FILE} | cut -d: -f1 | tail -n 1)
-              note_message="Extension is missing ${missing}. Consider adding [Quarto Wizard](https://m.canouil.dev/quarto-wizard/) support to provide autocompletion, validation, hover documentation, and code snippets in editors. See [Schema Specification](https://m.canouil.dev/quarto-wizard/reference/schema-specification.html) and [Snippet Specification](https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html)."
-              notes_json=$(echo ${notes_json} | jq --compact-output --arg line "${line_number}" --arg message "${note_message}" '. += [{"line": $line, "message": $message}]')
-            done < diff.patch
-          fi
-          echo "notes=${notes_json}" >> ${GITHUB_OUTPUT}
+        run: bash .github/scripts/check-extensions/check-wizard.sh
       - name: Store notes
         if: always() && needs.check-submission.outputs.submission == 'true'
         id: store-notes
@@ -525,8 +352,10 @@ jobs:
                 "${TOPICS_RESULT}" == "failure" || \
                 "${DESCRIPTION_RESULT}" == "failure" || \
                 "${RELEASE_RESULT}" == "failure" || \
-                "${REDIRECTION_RESULT}" == "failure" || \
-                "${STRUCTURE_RESULT}" == "failure" ]]; then
+                "${REDIRECTION_RESULT}" == "failure" ]]; then
+            errors_found=true
+          fi
+          if [[ "${STRUCTURE_RESULT}" == "failure" ]]; then
             errors_found=true
           fi
 
@@ -572,7 +401,9 @@ jobs:
             echo "🔍 [View workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})" >> "${GITHUB_STEP_SUMMARY}"
           fi
 
-          if [[ "${WIZARD_NOTES}" != "[]" && "${WIZARD_NOTES}" != "" ]]; then
+          ALL_NOTES="${WIZARD_NOTES:-[]}"
+
+          if [[ "${ALL_NOTES}" != "[]" && "${ALL_NOTES}" != "" ]]; then
             declare -A file_line_notes
 
             while read -r note_obj; do
@@ -583,7 +414,7 @@ jobs:
               else
                 file_line_notes["${line}"]+=$'\n- 💡 '"${message}"
               fi
-            done < <(echo "${WIZARD_NOTES}" | jq -c ".[]")
+            done < <(echo "${ALL_NOTES}" | jq -c ".[]")
 
             echo "---" >> "${GITHUB_STEP_SUMMARY}"
             echo "" >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -85,7 +85,7 @@ jobs:
     env:
       IMAGE: ${{ matrix.image_ref }}
       QUARTO_CHANNEL: ${{ matrix.quarto_channel }}
-      RENDER_CONCURRENCY: ${{ inputs.render_concurrency || '2' }}
+      RENDER_CONCURRENCY: ${{ inputs.render_concurrency }}
     steps:
       - name: Checkout scripts
         uses: actions/checkout@v7

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -9,6 +9,9 @@ on:
       batch_size:
         description: "Number of extensions per batch"
         default: "25"
+      render_concurrency:
+        description: "Number of concurrent renders per batch"
+        default: "2"
   schedule:
     - cron: "0 14 15 * *"
 
@@ -82,6 +85,7 @@ jobs:
     env:
       IMAGE: ${{ matrix.image_ref }}
       QUARTO_CHANNEL: ${{ matrix.quarto_channel }}
+      RENDER_CONCURRENCY: ${{ inputs.render_concurrency || '2' }}
     steps:
       - name: Checkout scripts
         uses: actions/checkout@v7
@@ -108,14 +112,7 @@ jobs:
 
       - name: Prepare render image
         if: steps.inspect-batch.outputs.count != '0'
-        run: |
-          set -euo pipefail
-          if [[ ! "${IMAGE}" =~ @sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::Image reference '${IMAGE}' is not a valid digest-pinned reference."
-            exit 1
-          fi
-          docker pull "${IMAGE}"
-          docker tag "${IMAGE}" render-image
+        run: bash .github/scripts/test-extensions/prepare-image.sh
 
       - name: Clone extensions
         if: steps.inspect-batch.outputs.count != '0'


### PR DESCRIPTION
The monthly test pipeline now renders each batch in concurrent shards (RENDER_CONCURRENCY, default 2), selects one CTAN mirror per job and bakes it into the render image instead of negotiating per extension, shares renv/uv/Julia package caches across extensions within a job (with a per-shard R library), and retries dependency installs once on non-timeout failures. The dependency-install and render container scripts move out of heredocs into standalone files, and image preparation is consolidated in prepare-image.sh.

Every test result now carries a stage (clone, policy, deps, render) and failure reason, so dependency-caused failures are counted and linked separately from render failures in the published summary. The fields are additive; existing consumers of test-results.json are unaffected.

Submission PRs get a new check-render job: the added extensions are rendered with the release-channel test image through the same harness, inside the existing hardened container sandbox with read-only permissions. Outcomes reach the submitter through the sticky PR comment, with the failure stage and a stderr excerpt plus a link to the preflight-render-logs artefact; nothing is committed to any branch. Failures are advisory by default and become blocking when the CHECK_RENDER_BLOCKING repository variable is set to true. Pre-flight is capped at five entries and renders each repository once.

The submission checks themselves are repaired and consolidated: the redirection check read an unset variable and never inspected any repository, the topics check compared against the literal "[]" string gh returns for topic-less repositories, and the workflow concurrency group made concurrent submission PRs cancel each other. The six inline check bodies move into .github/scripts/check-extensions/ over a shared lib.sh (entry parsing, retried tree fetch, error/note accumulation), giving them shellcheck and shfmt coverage.