### PR TITLE
fix(ci): accept a git tag when no release is published

### DIFF
--- a/.github/scripts/check-extensions/check-release.sh
+++ b/.github/scripts/check-extensions/check-release.sh
@@ -12,7 +12,10 @@ while IFS=, read -r entry; do
 	repo=$(entry_repo "${entry}")
 	repo_release=$(gh repo view --json latestRelease "${repo}" --jq ".latestRelease")
 	if [[ -z "${repo_release}" ]]; then
-		add_error "${entry}" "Repository is missing release/tag."
+		repo_tags=$(gh api "repos/${repo}/tags" --jq "length" 2>/dev/null || echo 0)
+		if [[ "${repo_tags:-0}" -eq 0 ]]; then
+			add_error "${entry}" "Repository is missing release/tag."
+		fi
 	fi
 done < <(read_diff_entries)
 


### PR DESCRIPTION
The submission release check flagged repositories that ship git tags but no published GitHub Release, for example [`songwupei/quarto-gbt9704`](https://github.com/songwupei/quarto-gbt9704) which has two tags and no release. When `latestRelease` is empty the check now falls back to the tags endpoint and only errors when both a release and a tag are absent.