### PR TITLE
chore: add qcode extension

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -352,3 +352,4 @@ nessan/simple-vars
 WEHI-ResearchComputing/QuartoCards
 pbosetti/simpleicons
 rkskmt/quarto-cleanslidekit-revealjs
+skyfroger/qcode


### PR DESCRIPTION
## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

qCode is an extension for Quarto that adds an interactive Python IDE to your page with the ability to run code directly in the browser, as well as search documentation for Python functions and methods.
