### PR TITLE
chore: add seandavi/quarto-livefigures

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -354,3 +354,4 @@ pbosetti/simpleicons
 rkskmt/quarto-cleanslidekit-revealjs
 skyfroger/qcode
 songwupei/quarto-gbt9704
+seandavi/quarto-livefigures


### PR DESCRIPTION
Adds [quarto-livefigures](https://github.com/seandavi/quarto-livefigures) — editable, version-controlled figures rendered at build time from 18 plain-text formats (Excalidraw, Vega-Lite, Graphviz, PlantUML, WaveDrom, D2, …), as file references or fenced blocks, with content-addressed caching and native figure semantics.

Checklist:
- [x] Not already listed
- [x] Repository description set
- [x] Topics set
- [x] Tagged release (v0.7.1)
- [x] `template.qmd` at repo root
- [x] Single extension under `_extensions`

Docs: <https://livefigures.seandavis.net>