### PR TITLE
chore: add ravila4/quarto-link-previews

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -290,6 +290,7 @@ quarto-monash/thesis
 quarto-monash/workingpaper
 r-wasm/quarto-drop
 r-wasm/quarto-live
+ravila4/quarto-link-previews
 rchaput/acronyms
 resepemb/quarto-kroki
 restlessronin/gfm-strip-disallowed


### PR DESCRIPTION
## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

`link-previews` gives Quarto websites hover previews for their internal links, the way Quartz digital gardens and Obsidian's page preview do. Rest the pointer on a link to another page of the site and a popover shows that page's title block and content, so a reader can judge whether the jump is worth making. A link to a section opens the preview already scrolled to that heading.

On first hover the target page is fetched (same origin, so it is already on the reader's host), its article content is extracted, and it is shown through the tippy.js bundle Quarto loads for footnote and cross-reference hovers. Popovers pick up the site theme in both light and dark mode. Navigation chrome, external links, footnotes, cross-references, lightbox images and downloads are all skipped, and there are opt-outs per link, per region, per page and site-wide. The extension also ships `_schema.yml` and `_snippets.json`, so Quarto Wizard has completion and validation for its five options.

Docs and live demo, with the filter running on the site itself: <https://ravila4.github.io/quarto-link-previews/>
