### PR TITLE
feat: add quarto-mail extension

### DIFF
--- a/extensions/quarto-extensions.csv
+++ b/extensions/quarto-extensions.csv
@@ -177,6 +177,7 @@ martinomagnifico/quarto-verticator
 mateusmolina/custom-amsthm-environments
 maucejo/quarto-bookly
 mavam/quarto-brief
+mavam/quarto-mail
 mcanouil/quarto-animate
 mcanouil/quarto-atelier
 mcanouil/quarto-badge


### PR DESCRIPTION
## Extension Submission

I confirm that I have checked that:

- [x] I have checked that the extension GitHub repository has a description.
- [x] I have checked that the extension GitHub repository has topics.

- [x] The extension is not already listed.
- [x] The GitHub repository contains a **Description**.
  - There are no special characters/strings in the **Description**, such as `'<style>'` instead of `` `<style>` ``.
- [x] The GitHub repository contains **Topics**.
- [x] The GitHub repository contains a **Release** with **Tag**.
- [x] The GitHub repository has `example.qmd` or `template.qmd` file.
- [x] The GitHub repository has only one extension or a set of extensions.

## Description

Adds [quarto-mail](https://github.com/mavam/quarto-mail), a Quarto extension for authoring email in Markdown and rendering deterministic plain-text, HTML, MIME, and reviewable Gmail delivery artifacts.
