### PR TITLE
fix: correct Python dependency auto-detect in pre-flight render

### DIFF
--- a/.github/scripts/test-extensions/deps-install.sh
+++ b/.github/scripts/test-extensions/deps-install.sh
@@ -26,6 +26,17 @@ detect_engines() {
 
 engines=$(detect_engines)
 
+# A documentation website under docs/ is a separate project that documents the
+# extension rather than exercising it, and render-inner.sh keeps it out of the
+# render surface. Its dependencies are therefore not needed, unless the
+# repository holds nothing else.
+qmd_list=$(mktemp)
+trap 'rm -f "${qmd_list}"' EXIT
+find . -type f -name '*.qmd' -not -path './_extensions/*' -not -path './docs/*' -print0 >"${qmd_list}"
+if [[ ! -s "${qmd_list}" ]]; then
+	find . -type f -name '*.qmd' -not -path './_extensions/*' -print0 >"${qmd_list}"
+fi
+
 # Auto-detect R dependencies when no renv.lock is present
 if [[ ! -f renv.lock ]]; then
 	if echo "${engines}" | grep -qx "knitr"; then
@@ -57,7 +68,7 @@ if [[ ! -f uv.lock ]] && [[ ! -f requirements.txt ]]; then
 				has_python=true
 				break
 			fi
-		done < <(find . -name '*.qmd' -not -path './_extensions/*' -print0)
+		done <"${qmd_list}"
 
 		if [[ "${has_python}" == "true" ]]; then
 			echo "Auto-detecting Python dependencies for ${EXT_ID} (jupyter engine, no lock file)." >>"${LOG_DIR}/stdout.log"
@@ -68,8 +79,7 @@ if [[ ! -f uv.lock ]] && [[ ! -f requirements.txt ]]; then
 			# shellcheck disable=SC1091 # created at runtime by uv venv
 			source .venv/bin/activate
 
-			deps=$(find . -name '*.qmd' -not -path './_extensions/*' -print0 |
-				xargs -0 python3 -c '
+			deps=$(xargs -0 python3 -c '
 import sys, ast, re
 from pathlib import Path
 
@@ -145,7 +155,10 @@ for path in sys.argv[1:]:
 third_party = imports - stdlib - local - {"__future__"}
 for pkg in sorted({DISTRIBUTIONS.get(name, name) for name in third_party}):
     print(pkg)
-' 2>/dev/null) || deps=""
+' <"${qmd_list}" 2>>"${LOG_DIR}/stderr.log") || {
+				echo "Python dependency detection failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+				exit 1
+			}
 
 			if [[ -n "${deps}" ]]; then
 				echo "Installing Python packages: ${deps//$'\n'/, }" >>"${LOG_DIR}/stdout.log"
@@ -170,14 +183,13 @@ if [[ ! -f Project.toml ]] && [[ ! -f JuliaProject.toml ]]; then
 				has_julia=true
 				break
 			fi
-		done < <(find . -name '*.qmd' -not -path './_extensions/*' -print0)
+		done <"${qmd_list}"
 
 		if [[ "${has_julia}" == "true" ]]; then
 			echo "Auto-detecting Julia dependencies for ${EXT_ID} (jupyter engine, no Project.toml)." >>"${LOG_DIR}/stdout.log"
 
 			deps=$(
-				find . -name '*.qmd' -not -path './_extensions/*' -print0 |
-					xargs -0 grep -hP '^\s*(using|import)\s+' 2>/dev/null |
+				xargs -0 grep -hP '^\s*(using|import)\s+' <"${qmd_list}" 2>/dev/null |
 					sed -E 's/^\s*(using|import)\s+//' |
 					sed -E 's/:.*//' |
 					tr ',' '\n' |

--- a/.github/scripts/test-extensions/deps-install.sh
+++ b/.github/scripts/test-extensions/deps-install.sh
@@ -61,7 +61,7 @@ if [[ ! -f uv.lock ]] && [[ ! -f requirements.txt ]]; then
 
 		if [[ "${has_python}" == "true" ]]; then
 			echo "Auto-detecting Python dependencies for ${EXT_ID} (jupyter engine, no lock file)." >>"${LOG_DIR}/stdout.log"
-			uv venv >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+			uv venv --clear >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
 				echo "uv venv failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
 				exit 1
 			}
@@ -71,13 +71,53 @@ if [[ ! -f uv.lock ]] && [[ ! -f requirements.txt ]]; then
 			deps=$(find . -name '*.qmd' -not -path './_extensions/*' -print0 |
 				xargs -0 python3 -c '
 import sys, ast, re
+from pathlib import Path
+
+# Modules whose distribution name on PyPI differs from the import name.
+DISTRIBUTIONS = {
+    "Bio": "biopython",
+    "IPython": "ipython",
+    "OpenSSL": "pyopenssl",
+    "PIL": "pillow",
+    "attr": "attrs",
+    "bs4": "beautifulsoup4",
+    "cv2": "opencv-python",
+    "dateutil": "python-dateutil",
+    "docx": "python-docx",
+    "fitz": "pymupdf",
+    "git": "gitpython",
+    "mpl_toolkits": "matplotlib",
+    "pptx": "python-pptx",
+    "serial": "pyserial",
+    "skimage": "scikit-image",
+    "sklearn": "scikit-learn",
+    "yaml": "pyyaml",
+    "zmq": "pyzmq",
+}
 
 stdlib = set(sys.stdlib_module_names) if hasattr(sys, "stdlib_module_names") else set()
 imports = set()
+local = set()
 chunk_re = re.compile(r"^\s*```\{python[^}]*\}\s*$")
 end_re = re.compile(r"^\s*```\s*$")
 
+
+def local_modules(directory):
+    names = set()
+    for entry in directory.iterdir():
+        if entry.name == "_extensions":
+            continue
+        if entry.is_file() and entry.suffix == ".py":
+            names.add(entry.stem)
+        elif entry.is_dir() and (entry / "__init__.py").is_file():
+            names.add(entry.name)
+    return names
+
+
+local |= local_modules(Path("."))
+
 for path in sys.argv[1:]:
+    local |= local_modules(Path(path).parent)
     in_chunk = False
     lines = []
     with open(path) as f:
@@ -95,7 +135,7 @@ for path in sys.argv[1:]:
                             for alias in node.names:
                                 imports.add(alias.name.split(".")[0])
                         elif isinstance(node, ast.ImportFrom):
-                            if node.module:
+                            if node.level == 0 and node.module:
                                 imports.add(node.module.split(".")[0])
                 except SyntaxError:
                     pass
@@ -103,8 +143,8 @@ for path in sys.argv[1:]:
             elif in_chunk:
                 lines.append(line.rstrip())
 
-third_party = sorted(imports - stdlib - {"__future__"})
-for pkg in third_party:
+third_party = imports - stdlib - local - {"__future__"}
+for pkg in sorted({DISTRIBUTIONS.get(name, name) for name in third_party}):
     print(pkg)
 ' 2>/dev/null) || deps=""
 
@@ -186,7 +226,7 @@ if [[ -f renv.lock ]]; then
 fi
 if [[ -f uv.lock ]] || [[ -f requirements.txt ]]; then
 	echo "Installing Python dependencies for ${EXT_ID}." >>"${LOG_DIR}/stdout.log"
-	uv venv >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+	uv venv --clear >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
 		echo "uv venv failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
 		exit 1
 	}

--- a/.github/scripts/test-extensions/deps-install.sh
+++ b/.github/scripts/test-extensions/deps-install.sh
@@ -97,7 +97,6 @@ DISTRIBUTIONS = {
 
 stdlib = set(sys.stdlib_module_names) if hasattr(sys, "stdlib_module_names") else set()
 imports = set()
-local = set()
 chunk_re = re.compile(r"^\s*```\{python[^}]*\}\s*$")
 end_re = re.compile(r"^\s*```\s*$")
 
@@ -114,10 +113,10 @@ def local_modules(directory):
     return names
 
 
-local |= local_modules(Path("."))
+directories = {Path(".")} | {Path(path).parent for path in sys.argv[1:]}
+local = set().union(*(local_modules(directory) for directory in directories))
 
 for path in sys.argv[1:]:
-    local |= local_modules(Path(path).parent)
     in_chunk = False
     lines = []
     with open(path) as f:


### PR DESCRIPTION
The pre-flight render harness auto-detects Python dependencies when an extension carries no lock file. It passed each import name straight to `uv pip install`, so a module whose distribution name on PyPI differs made the whole install unsatisfiable. `chrischizinski/quarto-sciposter` failed this way on `import yaml`, which is published as `pyyaml`, and no render ran.

- Map the known import names to their distribution names, and drop imports that resolve to a module inside the extension repository itself.
- Create the virtual environment with `--clear`. The dependency install is retried once, and the second attempt always stopped on the environment left behind by the first, which hid the true cause of the failure.
- Build the list of documents once, and exclude `docs/` from it the same way the render step does. An import that only a documentation page makes no longer installs a package, and no longer fails an extension for content that is never rendered.
- Report a failure of the detection step instead of reading it as an empty dependency list. Its errors went to `/dev/null`, so a document the interpreter could not read was reported as no dependencies, and the render failed later with an unrelated missing module.

Checked in the release container against the extension from the failing run, which now installs `pyyaml` and exits zero, and against fixtures for the `docs/` exclusion, the fallback when a repository holds nothing else, and a detection failure. Running the script twice over the same directory now succeeds, which is the retry path.