### PR TITLE
feat: test untested extensions after each harvest

### DIFF
--- a/.github/scripts/test-extensions/build-matrix.sh
+++ b/.github/scripts/test-extensions/build-matrix.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 # Build the test matrix for the test-extensions workflow.
-# Inputs (env): DEBUG, FAILING_ONLY, BATCH_SIZE, GH_TOKEN (for gh api calls)
+# Inputs (env): DEBUG, FAILING_ONLY, NEW_ONLY, BATCH_SIZE, GH_TOKEN (for gh api calls)
 # Inputs (env, debug only): REPO_OWNER (filters to same-owner extensions)
-# Inputs (files, failing-only): test-results.json (from quarto-tests branch)
-# Outputs (to GITHUB_OUTPUT): matrix, skipped
+# Inputs (files, failing-only and new-only): test-results.json (from quarto-tests branch)
+# Outputs (to GITHUB_OUTPUT): matrix, skipped, count
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=retry.sh
@@ -24,12 +24,44 @@ if [[ ! "${FAILING_ONLY}" =~ ^(true|false)$ ]]; then
   exit 1
 fi
 
+NEW_ONLY="${NEW_ONLY:-false}"
+if [[ ! "${NEW_ONLY}" =~ ^(true|false)$ ]]; then
+  echo "::error::Invalid new_only value: '${NEW_ONLY}'. Expected 'true' or 'false'."
+  exit 1
+fi
+
+# New-only selects extensions with no stored result at all, which is a subset of
+# what failing-only selects, so the two modes together mean new-only.
+if [[ "${NEW_ONLY}" == "true" ]] && [[ "${FAILING_ONLY}" == "true" ]]; then
+  echo "::notice::new_only and failing_only are both set. Using new_only."
+  FAILING_ONLY="false"
+fi
+
 if [[ ! "${BATCH_SIZE}" =~ ^[1-9][0-9]*$ ]]; then
   echo "::error::Invalid batch_size value: '${BATCH_SIZE}'. Expected a positive integer."
   exit 1
 fi
 
 extensions_json=$(cat quarto-extensions.json)
+if [[ "${NEW_ONLY}" == "true" ]]; then
+  tested_ids_file=$(mktemp)
+  if [[ -f test-results.json ]] && jq -e 'type == "object"' test-results.json >/dev/null 2>&1; then
+    jq -c 'keys' test-results.json >"${tested_ids_file}"
+  else
+    echo "::warning::Missing or invalid test-results.json. Treating every extension as never tested."
+    echo '[]' >"${tested_ids_file}"
+  fi
+  # Filtering here, before the repository trees are fetched, keeps the tree
+  # requests to the extensions that actually need a first test.
+  # --slurpfile keeps the identifier list off the jq command line, hence $t[0].
+  extensions_json=$(echo "${extensions_json}" | jq -c --slurpfile t "${tested_ids_file}" '
+    ($t[0] | map({(.): true}) | add // {}) as $tested
+    | with_entries(select($tested[.key] | not))
+  ')
+  rm -f "${tested_ids_file}"
+  echo "New-only mode: $(echo "${extensions_json}" | jq 'length') extension(s) with no stored result."
+fi
+
 if [[ "${DEBUG}" == "true" ]]; then
   if [[ -z "${REPO_OWNER:-}" ]]; then
     echo "::error::REPO_OWNER is not set."
@@ -229,6 +261,11 @@ if [[ "${FAILING_ONLY}" == "true" ]]; then
   echo "Failing-only selection: release=${rel_count}, prerelease=${pre_count}"
 fi
 
+# Extensions to render across both channels. The workflow skips the render and
+# publication jobs when this is zero, so a run with nothing to do stops here.
+count=$(echo "${entries_by_channel}" | jq '[.release, .prerelease] | map(length) | add')
+echo "Extensions to render: ${count}"
+
 matrix=$(echo "${entries_by_channel}" | jq -c --argjson n "${BATCH_SIZE}" --argjson meta "${image_meta_map}" '
   def pad3: tostring | if length < 3 then ("000" + .)[-3:] else . end;
   . as $byc
@@ -259,5 +296,8 @@ matrix=$(echo "${entries_by_channel}" | jq -c --argjson n "${BATCH_SIZE}" --argj
 job_count=$(echo "${matrix}" | jq '.include | length')
 echo "Matrix jobs: ${job_count}"
 
-echo "matrix=$(echo "${matrix}" | jq -c '.')" >>"${GITHUB_OUTPUT}"
-echo "skipped=$(echo "${skipped}" | jq -c '.')" >>"${GITHUB_OUTPUT}"
+{
+  echo "matrix=$(echo "${matrix}" | jq -c '.')"
+  echo "skipped=$(echo "${skipped}" | jq -c '.')"
+  echo "count=${count}"
+} >>"${GITHUB_OUTPUT}"

--- a/.github/scripts/test-extensions/build-matrix.sh
+++ b/.github/scripts/test-extensions/build-matrix.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # Build the test matrix for the test-extensions workflow.
-# Inputs (env): DEBUG, FAILING_ONLY, NEW_ONLY, BATCH_SIZE, GH_TOKEN (for gh api calls)
+# Inputs (env): DEBUG, FAILING_ONLY, UNTESTED_ONLY, BATCH_SIZE, GH_TOKEN (for gh api calls)
 # Inputs (env, debug only): REPO_OWNER (filters to same-owner extensions)
-# Inputs (files, failing-only and new-only): test-results.json (from quarto-tests
+# Inputs (files, failing-only and untested-only): test-results.json (from quarto-tests
 #               branch); rewritten in place when missing or malformed
 # Outputs (to GITHUB_OUTPUT): matrix, skipped, render_count
 
@@ -25,9 +25,9 @@ if [[ ! "${FAILING_ONLY}" =~ ^(true|false)$ ]]; then
   exit 1
 fi
 
-NEW_ONLY="${NEW_ONLY:-false}"
-if [[ ! "${NEW_ONLY}" =~ ^(true|false)$ ]]; then
-  echo "::error::Invalid new_only value: '${NEW_ONLY}'. Expected 'true' or 'false'."
+UNTESTED_ONLY="${UNTESTED_ONLY:-false}"
+if [[ ! "${UNTESTED_ONLY}" =~ ^(true|false)$ ]]; then
+  echo "::error::Invalid untested_only value: '${UNTESTED_ONLY}'. Expected 'true' or 'false'."
   exit 1
 fi
 
@@ -38,7 +38,7 @@ fi
 
 # Both selection modes read the stored results, so normalise the document once.
 # A missing or malformed file means nothing has been tested yet.
-if [[ "${NEW_ONLY}" == "true" ]] || [[ "${FAILING_ONLY}" == "true" ]]; then
+if [[ "${UNTESTED_ONLY}" == "true" ]] || [[ "${FAILING_ONLY}" == "true" ]]; then
   if [[ ! -f test-results.json ]] || ! jq -e 'type == "object"' test-results.json >/dev/null 2>&1; then
     echo "::warning::Missing or invalid test-results.json. Treating every extension as never tested."
     echo '{}' >test-results.json
@@ -46,14 +46,14 @@ if [[ "${NEW_ONLY}" == "true" ]] || [[ "${FAILING_ONLY}" == "true" ]]; then
 fi
 
 extensions_json=$(cat quarto-extensions.json)
-if [[ "${NEW_ONLY}" == "true" ]]; then
+if [[ "${UNTESTED_ONLY}" == "true" ]]; then
   # Filtering here, before the repository trees are fetched, keeps the tree
-  # requests to the extensions that need a first test.
+  # requests to the extensions that need a first result.
   # --slurpfile keeps the stored results off the jq command line, hence $tr[0].
   extensions_json=$(jq -c --slurpfile tr test-results.json '
     with_entries(.key as $id | select($tr[0] | has($id) | not))
   ' <<<"${extensions_json}")
-  echo "New-only mode: $(jq 'length' <<<"${extensions_json}") extension(s) with no stored result."
+  echo "Untested-only mode: $(jq 'length' <<<"${extensions_json}") extension(s) with no stored result."
 fi
 
 if [[ "${DEBUG}" == "true" ]]; then
@@ -162,7 +162,7 @@ skipped='[]'
 if [[ -s "${skipped_file}" ]]; then
   skipped=$(jq -sc '.' "${skipped_file}")
   # The publication job reports this list too, but it does not run when nothing
-  # is rendered, which is the usual outcome of a new-only run.
+  # is rendered, which is the usual outcome of an untested-only run.
   echo "Skipped (no renderable content found): $(jq -r 'join(", ")' <<<"${skipped}")"
 fi
 entries=$(jq -nc --argjson a "${entries_phase_a}" --argjson b "${phase_b_entries}" '$a + $b')

--- a/.github/scripts/test-extensions/build-matrix.sh
+++ b/.github/scripts/test-extensions/build-matrix.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 # Build the test matrix for the test-extensions workflow.
 # Inputs (env): DEBUG, FAILING_ONLY, UNTESTED_ONLY, BATCH_SIZE, GH_TOKEN (for gh api calls)
-# Inputs (env, untested-only): MAX_UNTESTED (extensions per run, default 25)
+# Inputs (env, untested-only): MAX_UNTESTED (extensions per run, default 25),
+#               UNTESTED_WINDOW_DAYS (how recently the extension was listed,
+#               default 7, 0 for no window), GITHUB_REPOSITORY
 # Inputs (env, debug only): REPO_OWNER (filters to same-owner extensions)
 # Inputs (files, failing-only and untested-only): test-results.json (from quarto-tests
 #               branch); rewritten in place when missing or malformed
@@ -43,6 +45,40 @@ if [[ ! "${MAX_UNTESTED}" =~ ^[1-9][0-9]*$ ]]; then
   exit 1
 fi
 
+UNTESTED_WINDOW_DAYS="${UNTESTED_WINDOW_DAYS:-7}"
+if [[ ! "${UNTESTED_WINDOW_DAYS}" =~ ^[0-9]+$ ]]; then
+  echo "::error::Invalid untested_window_days value: '${UNTESTED_WINDOW_DAYS}'. Expected a non-negative integer."
+  exit 1
+fi
+
+if [[ "${UNTESTED_ONLY}" == "true" ]] && [[ "${UNTESTED_WINDOW_DAYS}" -gt 0 ]] && [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+  echo "::error::GITHUB_REPOSITORY is not set. It names the repository whose extension list holds the recent additions."
+  exit 1
+fi
+
+# Entries added to the extension list in the last window, one per line. An
+# extension that cannot be rendered never gets a stored result, so without this
+# window it would be selected by every run for ever.
+recent_csv_entries() {
+  local repo="$1" days="$2" csv="extensions/quarto-extensions.csv"
+  local since shas commit_file
+  since=$(jq -rn --argjson t "$(($(date -u +%s) - days * 86400))" '$t | todate')
+  if ! shas=$(retry 3 2 gh api \
+    "repos/${repo}/commits?path=${csv}&since=${since}&per_page=100" --jq '.[].sha' 2>/dev/null); then
+    return 1
+  fi
+  [[ -z "${shas}" ]] && return 0
+  commit_file=$(mktemp)
+  while read -r sha; do
+    if ! retry 3 2 gh api "repos/${repo}/commits/${sha}" >"${commit_file}" 2>/dev/null; then
+      rm -f "${commit_file}"
+      return 1
+    fi
+    jq -r --arg f "${csv}" '.files[]? | select(.filename == $f) | .patch // ""' "${commit_file}"
+  done <<<"${shas}" | grep '^+[^+]' | sed 's/^+//' | tr -d '\r' | sort -u
+  rm -f "${commit_file}"
+}
+
 # Both selection modes read the stored results, so normalise the document once.
 # A missing or malformed file means nothing has been tested yet.
 if [[ "${UNTESTED_ONLY}" == "true" ]] || [[ "${FAILING_ONLY}" == "true" ]]; then
@@ -62,6 +98,23 @@ if [[ "${UNTESTED_ONLY}" == "true" ]]; then
   ' <<<"${extensions_json}")
   untested_total=$(jq 'length' <<<"${extensions_json}")
   echo "Untested-only mode: ${untested_total} extension(s) with no stored result."
+
+  if [[ "${UNTESTED_WINDOW_DAYS}" -gt 0 ]] && [[ "${untested_total}" -gt 0 ]]; then
+    recent_file=$(mktemp)
+    if recent_csv_entries "${GITHUB_REPOSITORY}" "${UNTESTED_WINDOW_DAYS}" >"${recent_file}"; then
+      extensions_json=$(jq -c --rawfile recent "${recent_file}" '
+        ($recent | split("\n") | map(select(length > 0))) as $added
+        | with_entries(.key as $id | select($added | index($id)))
+      ' <<<"${extensions_json}")
+      echo "Listed in the last ${UNTESTED_WINDOW_DAYS} day(s): $(jq 'length' <<<"${extensions_json}") of ${untested_total}."
+    else
+      echo "::warning::Could not read the recent additions to the extension list. Selecting nothing; the next run tries again."
+      extensions_json='{}'
+    fi
+    rm -f "${recent_file}"
+    untested_total=$(jq 'length' <<<"${extensions_json}")
+  fi
+
   # A reset or malformed test-results.json makes every extension untested. The
   # cap keeps that from launching a full run on a path that reuses the images
   # as they stand; the rest are taken by the following runs.

--- a/.github/scripts/test-extensions/build-matrix.sh
+++ b/.github/scripts/test-extensions/build-matrix.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 # Build the test matrix for the test-extensions workflow.
 # Inputs (env): DEBUG, FAILING_ONLY, NEW_ONLY, BATCH_SIZE, GH_TOKEN (for gh api calls)
 # Inputs (env, debug only): REPO_OWNER (filters to same-owner extensions)
-# Inputs (files, failing-only and new-only): test-results.json (from quarto-tests branch)
-# Outputs (to GITHUB_OUTPUT): matrix, skipped, count
+# Inputs (files, failing-only and new-only): test-results.json (from quarto-tests
+#               branch); rewritten in place when missing or malformed
+# Outputs (to GITHUB_OUTPUT): matrix, skipped, render_count
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=retry.sh
@@ -30,36 +31,29 @@ if [[ ! "${NEW_ONLY}" =~ ^(true|false)$ ]]; then
   exit 1
 fi
 
-# New-only selects extensions with no stored result at all, which is a subset of
-# what failing-only selects, so the two modes together mean new-only.
-if [[ "${NEW_ONLY}" == "true" ]] && [[ "${FAILING_ONLY}" == "true" ]]; then
-  echo "::notice::new_only and failing_only are both set. Using new_only."
-  FAILING_ONLY="false"
-fi
-
 if [[ ! "${BATCH_SIZE}" =~ ^[1-9][0-9]*$ ]]; then
   echo "::error::Invalid batch_size value: '${BATCH_SIZE}'. Expected a positive integer."
   exit 1
 fi
 
+# Both selection modes read the stored results, so normalise the document once.
+# A missing or malformed file means nothing has been tested yet.
+if [[ "${NEW_ONLY}" == "true" ]] || [[ "${FAILING_ONLY}" == "true" ]]; then
+  if [[ ! -f test-results.json ]] || ! jq -e 'type == "object"' test-results.json >/dev/null 2>&1; then
+    echo "::warning::Missing or invalid test-results.json. Treating every extension as never tested."
+    echo '{}' >test-results.json
+  fi
+fi
+
 extensions_json=$(cat quarto-extensions.json)
 if [[ "${NEW_ONLY}" == "true" ]]; then
-  tested_ids_file=$(mktemp)
-  if [[ -f test-results.json ]] && jq -e 'type == "object"' test-results.json >/dev/null 2>&1; then
-    jq -c 'keys' test-results.json >"${tested_ids_file}"
-  else
-    echo "::warning::Missing or invalid test-results.json. Treating every extension as never tested."
-    echo '[]' >"${tested_ids_file}"
-  fi
   # Filtering here, before the repository trees are fetched, keeps the tree
-  # requests to the extensions that actually need a first test.
-  # --slurpfile keeps the identifier list off the jq command line, hence $t[0].
-  extensions_json=$(echo "${extensions_json}" | jq -c --slurpfile t "${tested_ids_file}" '
-    ($t[0] | map({(.): true}) | add // {}) as $tested
-    | with_entries(select($tested[.key] | not))
-  ')
-  rm -f "${tested_ids_file}"
-  echo "New-only mode: $(echo "${extensions_json}" | jq 'length') extension(s) with no stored result."
+  # requests to the extensions that need a first test.
+  # --slurpfile keeps the stored results off the jq command line, hence $tr[0].
+  extensions_json=$(jq -c --slurpfile tr test-results.json '
+    with_entries(.key as $id | select($tr[0] | has($id) | not))
+  ' <<<"${extensions_json}")
+  echo "New-only mode: $(jq 'length' <<<"${extensions_json}") extension(s) with no stored result."
 fi
 
 if [[ "${DEBUG}" == "true" ]]; then
@@ -174,15 +168,16 @@ image_meta_map=$(jq -nc '{}')
 for channel in release prerelease; do
   image_tag="ghcr.io/mcanouil/quarto-extensions:${channel}"
 
-  if ! retry 3 5 docker pull "${image_tag}" >/dev/null 2>&1; then
-    echo "::error::Failed to pull image '${image_tag}'."
-    exit 1
-  fi
-  image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "${image_tag}" 2>/dev/null || true)
-  if [[ -z "${image_ref}" ]]; then
+  # Read the digest from the registry manifest. The render jobs pull the image
+  # themselves, so downloading it here to inspect it would move gigabytes for
+  # a string.
+  image_digest=$(retry 3 5 docker buildx imagetools inspect "${image_tag}" \
+    --format '{{.Manifest.Digest}}' 2>/dev/null || true)
+  if [[ -z "${image_digest}" ]]; then
     echo "::error::Failed to resolve digest for image '${image_tag}'."
     exit 1
   fi
+  image_ref="${image_tag%:*}@${image_digest}"
   if [[ ! "${image_ref}" =~ @sha256:[0-9a-f]{64}$ ]]; then
     echo "::error::Resolved image reference '${image_ref}' is not a valid digest-pinned reference."
     exit 1
@@ -215,20 +210,14 @@ echo "Total extensions to test: ${total}"
 # Failing-only: per channel, keep extensions whose latest tested version failed,
 # or that have no stored result for that channel (never tested).
 entries_by_channel=$(jq -nc --argjson e "${entries}" '{release: $e, prerelease: $e}')
+count=$((total * 2))
 if [[ "${FAILING_ONLY}" == "true" ]]; then
-  test_results_file=$(mktemp)
   entries_file=$(mktemp)
-  if [[ -f test-results.json ]] && jq -e 'type == "object"' test-results.json >/dev/null 2>&1; then
-    cp test-results.json "${test_results_file}"
-  else
-    echo "::warning::Missing or invalid test-results.json. Treating all channels as never tested."
-    echo '{}' >"${test_results_file}"
-  fi
   printf '%s' "${entries}" >"${entries_file}"
   # Pass large JSON via files (--slurpfile) rather than --argjson so the entry
   # list and test history do not overflow ARG_MAX on the jq command line.
   # --slurpfile wraps each file's content in an array, hence $e[0] and $tr[0].
-  entries_by_channel=$(jq -nc --slurpfile e "${entries_file}" --slurpfile tr "${test_results_file}" '
+  entries_by_channel=$(jq -nc --slurpfile e "${entries_file}" --slurpfile tr test-results.json '
     def core(v): (v // "" | split("+")[0] | split("-")[0]
       | split(".") | map((tonumber? // 0)) | . + [0, 0, 0, 0] | .[0:4]);
     def suffix(v): (v // "" | split("+")[0] | split("-")[1:] | join("-"));
@@ -255,16 +244,16 @@ if [[ "${FAILING_ONLY}" == "true" ]]; then
         prerelease: [$entries[] | select(selected($results; .id; "prerelease"))]
       }
   ')
-  rm -f "${test_results_file}" "${entries_file}"
+  rm -f "${entries_file}"
   rel_count=$(echo "${entries_by_channel}" | jq '.release | length')
   pre_count=$(echo "${entries_by_channel}" | jq '.prerelease | length')
   echo "Failing-only selection: release=${rel_count}, prerelease=${pre_count}"
+  count=$((rel_count + pre_count))
 fi
 
-# Extensions to render across both channels. The workflow skips the render and
-# publication jobs when this is zero, so a run with nothing to do stops here.
-count=$(echo "${entries_by_channel}" | jq '[.release, .prerelease] | map(length) | add')
-echo "Extensions to render: ${count}"
+# Renders to run across both channels. The workflow skips the render and
+# publication jobs when this is zero.
+echo "Renders to run: ${count}"
 
 matrix=$(echo "${entries_by_channel}" | jq -c --argjson n "${BATCH_SIZE}" --argjson meta "${image_meta_map}" '
   def pad3: tostring | if length < 3 then ("000" + .)[-3:] else . end;
@@ -297,7 +286,7 @@ job_count=$(echo "${matrix}" | jq '.include | length')
 echo "Matrix jobs: ${job_count}"
 
 {
-  echo "matrix=$(echo "${matrix}" | jq -c '.')"
-  echo "skipped=$(echo "${skipped}" | jq -c '.')"
-  echo "count=${count}"
+  echo "matrix=${matrix}"
+  echo "skipped=${skipped}"
+  echo "render_count=${count}"
 } >>"${GITHUB_OUTPUT}"

--- a/.github/scripts/test-extensions/build-matrix.sh
+++ b/.github/scripts/test-extensions/build-matrix.sh
@@ -161,6 +161,9 @@ fi
 skipped='[]'
 if [[ -s "${skipped_file}" ]]; then
   skipped=$(jq -sc '.' "${skipped_file}")
+  # The publication job reports this list too, but it does not run when nothing
+  # is rendered, which is the usual outcome of a new-only run.
+  echo "Skipped (no renderable content found): $(jq -r 'join(", ")' <<<"${skipped}")"
 fi
 entries=$(jq -nc --argjson a "${entries_phase_a}" --argjson b "${phase_b_entries}" '$a + $b')
 
@@ -171,12 +174,15 @@ for channel in release prerelease; do
   # Read the digest from the registry manifest. The render jobs pull the image
   # themselves, so downloading it here to inspect it would move gigabytes for
   # a string.
+  inspect_error_file=$(mktemp)
   image_digest=$(retry 3 5 docker buildx imagetools inspect "${image_tag}" \
-    --format '{{.Manifest.Digest}}' 2>/dev/null || true)
+    --format '{{.Manifest.Digest}}' 2>"${inspect_error_file}" || true)
   if [[ -z "${image_digest}" ]]; then
-    echo "::error::Failed to resolve digest for image '${image_tag}'."
+    echo "::error::Failed to resolve digest for image '${image_tag}': $(tr '\n' ' ' <"${inspect_error_file}")"
+    rm -f "${inspect_error_file}"
     exit 1
   fi
+  rm -f "${inspect_error_file}"
   image_ref="${image_tag%:*}@${image_digest}"
   if [[ ! "${image_ref}" =~ @sha256:[0-9a-f]{64}$ ]]; then
     echo "::error::Resolved image reference '${image_ref}' is not a valid digest-pinned reference."

--- a/.github/scripts/test-extensions/build-matrix.sh
+++ b/.github/scripts/test-extensions/build-matrix.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Build the test matrix for the test-extensions workflow.
 # Inputs (env): DEBUG, FAILING_ONLY, UNTESTED_ONLY, BATCH_SIZE, GH_TOKEN (for gh api calls)
+# Inputs (env, untested-only): MAX_UNTESTED (extensions per run, default 25)
 # Inputs (env, debug only): REPO_OWNER (filters to same-owner extensions)
 # Inputs (files, failing-only and untested-only): test-results.json (from quarto-tests
 #               branch); rewritten in place when missing or malformed
@@ -36,6 +37,12 @@ if [[ ! "${BATCH_SIZE}" =~ ^[1-9][0-9]*$ ]]; then
   exit 1
 fi
 
+MAX_UNTESTED="${MAX_UNTESTED:-25}"
+if [[ ! "${MAX_UNTESTED}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::Invalid max_untested value: '${MAX_UNTESTED}'. Expected a positive integer."
+  exit 1
+fi
+
 # Both selection modes read the stored results, so normalise the document once.
 # A missing or malformed file means nothing has been tested yet.
 if [[ "${UNTESTED_ONLY}" == "true" ]] || [[ "${FAILING_ONLY}" == "true" ]]; then
@@ -53,7 +60,17 @@ if [[ "${UNTESTED_ONLY}" == "true" ]]; then
   extensions_json=$(jq -c --slurpfile tr test-results.json '
     with_entries(.key as $id | select($tr[0] | has($id) | not))
   ' <<<"${extensions_json}")
-  echo "Untested-only mode: $(jq 'length' <<<"${extensions_json}") extension(s) with no stored result."
+  untested_total=$(jq 'length' <<<"${extensions_json}")
+  echo "Untested-only mode: ${untested_total} extension(s) with no stored result."
+  # A reset or malformed test-results.json makes every extension untested. The
+  # cap keeps that from launching a full run on a path that reuses the images
+  # as they stand; the rest are taken by the following runs.
+  if [[ "${untested_total}" -gt "${MAX_UNTESTED}" ]]; then
+    echo "::warning::Testing ${MAX_UNTESTED} of ${untested_total} untested extensions. The rest are deferred to the next run."
+    extensions_json=$(jq -c --argjson n "${MAX_UNTESTED}" '
+      to_entries | sort_by(.key) | .[0:$n] | from_entries
+    ' <<<"${extensions_json}")
+  fi
 fi
 
 if [[ "${DEBUG}" == "true" ]]; then
@@ -178,7 +195,7 @@ for channel in release prerelease; do
   image_digest=$(retry 3 5 docker buildx imagetools inspect "${image_tag}" \
     --format '{{.Manifest.Digest}}' 2>"${inspect_error_file}" || true)
   if [[ -z "${image_digest}" ]]; then
-    echo "::error::Failed to resolve digest for image '${image_tag}': $(tr '\n' ' ' <"${inspect_error_file}")"
+    echo "::error::Failed to resolve digest for image '${image_tag}', which usually means the tag is gone or the image has never been built: $(tr '\n' ' ' <"${inspect_error_file}")"
     rm -f "${inspect_error_file}"
     exit 1
   fi
@@ -217,7 +234,10 @@ echo "Total extensions to test: ${total}"
 # or that have no stored result for that channel (never tested).
 entries_by_channel=$(jq -nc --argjson e "${entries}" '{release: $e, prerelease: $e}')
 count=$((total * 2))
-if [[ "${FAILING_ONLY}" == "true" ]]; then
+# Untested-only leaves nothing for failing-only to select: every survivor has no
+# stored result, so the per-channel filter would keep them all and the log line
+# would claim a selection that did not happen.
+if [[ "${FAILING_ONLY}" == "true" ]] && [[ "${UNTESTED_ONLY}" != "true" ]]; then
   entries_file=$(mktemp)
   printf '%s' "${entries}" >"${entries_file}"
   # Pass large JSON via files (--slurpfile) rather than --argjson so the entry

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
   workflow_run:
     workflows:
       - "Quarto Wizard"
+      - "Test Extensions"
     types:
       - completed
 
@@ -20,11 +21,16 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # The nightly Quarto Wizard run triggers this workflow on completion, not on
-    # success, so without this guard a failed harvest still redeploys the site.
+    # Both upstream workflows trigger this one on completion, not on success, so
+    # without this guard a failed harvest or test run still redeploys the site.
+    # A harvest that came from a push is a merged submission: the extension has
+    # no test result yet, so the deployment waits for Test Extensions to render
+    # and publish it, and the site ships with the result already in place.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.name == 'Test Extensions' ||
+      github.event.workflow_run.event != 'push'))
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,10 @@ name: Deploy
 
 on:
   workflow_dispatch:
+  # Test Extensions runs after every harvest, so this is the end of the chain:
+  # the site is rendered once the results of any new extension are published.
   workflow_run:
     workflows:
-      - "Quarto Wizard"
       - "Test Extensions"
     types:
       - completed
@@ -21,16 +22,11 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # Both upstream workflows trigger this one on completion, not on success, so
-    # without this guard a failed harvest or test run still redeploys the site.
-    # A harvest that came from a push is a merged submission: the extension has
-    # no test result yet, so the deployment waits for Test Extensions to render
-    # and publish it, and the site ships with the result already in place.
+    # The test run triggers this workflow on completion, not on success, so
+    # without this guard a failed run still redeploys the site.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-      (github.event.workflow_run.name == 'Test Extensions' ||
-      github.event.workflow_run.event != 'push'))
+      github.event.workflow_run.conclusion == 'success'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,8 @@ name: Deploy
 on:
   workflow_dispatch:
   # Test Extensions runs after every harvest, so this is the end of the chain:
-  # the site is rendered once the results of any new extension are published.
+  # the site is rendered once the results of any untested extension are
+  # published.
   workflow_run:
     workflows:
       - "Test Extensions"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,14 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # The test run triggers this workflow on completion, not on success, so
-    # without this guard a failed run still redeploys the site.
+    # The site content does not depend on the test results, so a batch that
+    # failed or timed out must still deploy. A cancelled run, and a run whose
+    # jobs were all skipped because the harvest itself failed, must not: there
+    # is either no fresh data or no complete run behind it.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion != 'cancelled' &&
+      github.event.workflow_run.conclusion != 'skipped')
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,10 +23,12 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # The site content does not depend on the test results, so a batch that
-    # failed or timed out must still deploy. A cancelled run, and a run whose
-    # jobs were all skipped because the harvest itself failed, must not: there
-    # is either no fresh data or no complete run behind it.
+    # The render restores test-results.json from the quarto-tests branch, so it
+    # always uses the last published results. A test run that failed a batch, or
+    # failed to publish, therefore deploys the fresh harvest data with the
+    # previous results, which is preferred over not deploying at all. A
+    # cancelled run, and a run whose jobs were all skipped because the harvest
+    # itself failed, deploy nothing: there is no fresh data behind them.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion != 'cancelled' &&

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -49,7 +49,7 @@ jobs:
     # The harvest triggers this workflow on completion, not on success, so
     # without this guard a failed harvest would test against stale data.
     if: >-
-      always() && needs.build-test-image.result != 'failure' &&
+      !cancelled() && needs.build-test-image.result != 'failure' &&
       (github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -9,12 +9,23 @@ on:
       failing_only:
         description: "If 'true', test only the channels currently failing or never tested"
         default: "false"
+      new_only:
+        description: "If 'true', test only the extensions with no stored result at all"
+        default: "false"
       batch_size:
         description: "Number of extensions per batch"
         default: "25"
       render_concurrency:
         description: "Number of concurrent renders per batch"
         default: "2"
+  # A completed harvest means quarto-extensions.json holds every submission
+  # merged since the last run, so a new-only pass gives each of them a first
+  # test result without waiting for the monthly schedule.
+  workflow_run:
+    workflows:
+      - "Quarto Wizard"
+    types:
+      - completed
   schedule:
     - cron: "0 14 15 * *"
 
@@ -24,6 +35,11 @@ concurrency:
 
 jobs:
   build-test-image:
+    # The harvest triggers this workflow on completion, not on success, so
+    # without this guard a failed harvest would test against stale data.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/build-test-image.yml
     permissions:
       contents: read
@@ -37,6 +53,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       skipped: ${{ steps.matrix.outputs.skipped }}
+      count: ${{ steps.matrix.outputs.count }}
     steps:
       - name: Checkout scripts
         uses: actions/checkout@v7
@@ -61,7 +78,10 @@ jobs:
           permission-metadata: read
 
       - name: Fetch stored test results
-        if: inputs.failing_only == 'true'
+        if: >-
+          inputs.failing_only == 'true' ||
+          inputs.new_only == 'true' ||
+          github.event_name == 'workflow_run'
         working-directory: _data
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -81,6 +101,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DEBUG: ${{ inputs.debug || 'false' }}
           FAILING_ONLY: ${{ inputs.failing_only || 'false' }}
+          NEW_ONLY: ${{ inputs.new_only || (github.event_name == 'workflow_run' && 'true') || 'false' }}
           BATCH_SIZE: ${{ inputs.batch_size || '25' }}
           REPO_OWNER: ${{ github.repository_owner }}
         shell: bash
@@ -90,6 +111,9 @@ jobs:
   test-extensions:
     name: test-extensions (batch ${{ matrix.batch_index }}, ${{ matrix.quarto_channel }})
     needs: [build-matrix]
+    # A new-only run finds nothing on most days, and an empty selection has
+    # nothing to render or publish.
+    if: needs.build-matrix.outputs.count != '0'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -168,7 +192,9 @@ jobs:
 
   summarise-and-publish:
     needs: [build-matrix, test-extensions]
-    if: always() && needs.build-matrix.result == 'success'
+    if: >-
+      always() && needs.build-matrix.result == 'success' &&
+      needs.build-matrix.outputs.count != '0'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -12,6 +12,9 @@ on:
       untested_only:
         description: "If 'true', test only the extensions with no stored result at all"
         default: "false"
+      untested_window_days:
+        description: "Untested-only: how recently the extension was listed, 0 for no window"
+        default: "7"
       batch_size:
         description: "Number of extensions per batch"
         default: "25"
@@ -19,8 +22,8 @@ on:
         description: "Number of concurrent renders per batch"
         default: "2"
   # A completed harvest means quarto-extensions.json is current, so an
-  # untested-only pass gives every extension with no stored result a first one
-  # without waiting for the monthly schedule.
+  # untested-only pass gives a first result to every extension that was listed
+  # recently and has none, without waiting for the monthly schedule.
   workflow_run:
     workflows:
       - "Quarto Wizard"
@@ -110,6 +113,7 @@ jobs:
           DEBUG: ${{ inputs.debug || 'false' }}
           FAILING_ONLY: ${{ inputs.failing_only || 'false' }}
           UNTESTED_ONLY: ${{ inputs.untested_only == 'true' || github.event_name == 'workflow_run' }}
+          UNTESTED_WINDOW_DAYS: ${{ inputs.untested_window_days || '7' }}
           BATCH_SIZE: ${{ inputs.batch_size || '25' }}
           REPO_OWNER: ${{ github.repository_owner }}
         shell: bash

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -33,11 +33,18 @@ concurrency:
   group: test-extensions
   cancel-in-progress: false
 
+# Deploy reads the conclusion of this workflow. A failed harvest skips every job
+# here, and the run then concludes 'skipped', which is what stops the site from
+# being deployed on stale data. A job that runs on 'always()' would conclude the
+# run 'success' instead and defeat that guard.
+
 jobs:
   build-test-image:
     # The harvest path renders a handful of extensions at most, and it runs
     # every day, so it uses the images as they stand rather than paying for a
-    # rebuild each night.
+    # rebuild each night. A first result therefore records the Quarto version of
+    # the last monthly build, which can be behind the current channel until the
+    # next full run tests the extension again.
     if: github.event_name != 'workflow_run'
     uses: ./.github/workflows/build-test-image.yml
     permissions:

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -9,7 +9,7 @@ on:
       failing_only:
         description: "If 'true', test only the channels currently failing or never tested"
         default: "false"
-      new_only:
+      untested_only:
         description: "If 'true', test only the extensions with no stored result at all"
         default: "false"
       batch_size:
@@ -18,9 +18,9 @@ on:
       render_concurrency:
         description: "Number of concurrent renders per batch"
         default: "2"
-  # A completed harvest means quarto-extensions.json holds every submission
-  # merged since the last run, so a new-only pass gives each of them a first
-  # test result without waiting for the monthly schedule.
+  # A completed harvest means quarto-extensions.json is current, so an
+  # untested-only pass gives every extension with no stored result a first one
+  # without waiting for the monthly schedule.
   workflow_run:
     workflows:
       - "Quarto Wizard"
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   build-test-image:
-    # The harvest path renders a handful of new extensions at most, and it runs
+    # The harvest path renders a handful of extensions at most, and it runs
     # every day, so it uses the images as they stand rather than paying for a
     # rebuild each night.
     if: github.event_name != 'workflow_run'
@@ -102,7 +102,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DEBUG: ${{ inputs.debug || 'false' }}
           FAILING_ONLY: ${{ inputs.failing_only || 'false' }}
-          NEW_ONLY: ${{ inputs.new_only == 'true' || github.event_name == 'workflow_run' }}
+          UNTESTED_ONLY: ${{ inputs.untested_only == 'true' || github.event_name == 'workflow_run' }}
           BATCH_SIZE: ${{ inputs.batch_size || '25' }}
           REPO_OWNER: ${{ github.repository_owner }}
         shell: bash
@@ -112,8 +112,8 @@ jobs:
   test-extensions:
     name: test-extensions (batch ${{ matrix.batch_index }}, ${{ matrix.quarto_channel }})
     needs: [build-matrix]
-    # A new-only run finds nothing on most days, and an empty selection has
-    # nothing to render or publish.
+    # An untested-only run finds nothing on most days, and an empty selection
+    # has nothing to render or publish.
     if: needs.build-matrix.outputs.render_count != '0'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -35,11 +35,10 @@ concurrency:
 
 jobs:
   build-test-image:
-    # The harvest triggers this workflow on completion, not on success, so
-    # without this guard a failed harvest would test against stale data.
-    if: >-
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
+    # The harvest path renders a handful of new extensions at most, and it runs
+    # every day, so it uses the images as they stand rather than paying for a
+    # rebuild each night.
+    if: github.event_name != 'workflow_run'
     uses: ./.github/workflows/build-test-image.yml
     permissions:
       contents: read
@@ -47,13 +46,19 @@ jobs:
 
   build-matrix:
     needs: [build-test-image]
+    # The harvest triggers this workflow on completion, not on success, so
+    # without this guard a failed harvest would test against stale data.
+    if: >-
+      always() && needs.build-test-image.result != 'failure' &&
+      (github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       skipped: ${{ steps.matrix.outputs.skipped }}
-      count: ${{ steps.matrix.outputs.count }}
+      render_count: ${{ steps.matrix.outputs.render_count }}
     steps:
       - name: Checkout scripts
         uses: actions/checkout@v7
@@ -78,10 +83,6 @@ jobs:
           permission-metadata: read
 
       - name: Fetch stored test results
-        if: >-
-          inputs.failing_only == 'true' ||
-          inputs.new_only == 'true' ||
-          github.event_name == 'workflow_run'
         working-directory: _data
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -101,7 +102,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DEBUG: ${{ inputs.debug || 'false' }}
           FAILING_ONLY: ${{ inputs.failing_only || 'false' }}
-          NEW_ONLY: ${{ inputs.new_only || (github.event_name == 'workflow_run' && 'true') || 'false' }}
+          NEW_ONLY: ${{ inputs.new_only == 'true' || github.event_name == 'workflow_run' }}
           BATCH_SIZE: ${{ inputs.batch_size || '25' }}
           REPO_OWNER: ${{ github.repository_owner }}
         shell: bash
@@ -113,7 +114,7 @@ jobs:
     needs: [build-matrix]
     # A new-only run finds nothing on most days, and an empty selection has
     # nothing to render or publish.
-    if: needs.build-matrix.outputs.count != '0'
+    if: needs.build-matrix.outputs.render_count != '0'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -194,7 +195,7 @@ jobs:
     needs: [build-matrix, test-extensions]
     if: >-
       always() && needs.build-matrix.result == 'success' &&
-      needs.build-matrix.outputs.count != '0'
+      needs.build-matrix.outputs.render_count != '0'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
An extension merged into the CSV had no test result until the monthly schedule ran, so the site showed it with no status for up to a month. The harvest now starts a test pass that covers the extensions listed recently that have no stored result, and the site deployment sits at the end of that chain, so a merged submission ships with its first result already in place.

- `build-matrix.sh` gains an `untested_only` mode. It selects the extensions with no key in `test-results.json` that were added to `extensions/quarto-extensions.csv` inside a window, seven days by default, read from the commits API. Absence alone would never terminate: an extension with no renderable content never gets a stored result, so the same eleven would be selected in every run. The selection is also capped, 25 per run by default, so a reset or malformed results file cannot launch a full run.
- Filtering happens before any repository tree is fetched, so the API requests go only to the extensions that need a first result. The `render_count` output lets the workflow skip the render and publication jobs when the selection is empty, which is the usual outcome.
- Test Extensions runs on the completion of Quarto Wizard and skips the image build on that path: a daily pass renders a handful of extensions at most and uses the images as they stand. A first result therefore records the Quarto version of the last monthly build.
- The matrix builder reads image digests from the registry manifest rather than pulling both Quarto images to inspect them, which is the pattern already used in `plan.sh`.
- Deploy now follows Test Extensions instead of Quarto Wizard. The render restores `test-results.json` from the `quarto-tests` branch, so a test run that failed a batch still deploys fresh harvest data with the previous results. A cancelled run, and a run whose jobs were all skipped behind a failed harvest, deploy nothing.

An extension that is listed but stays untested past the window waits for the monthly run. That happens only if the daily chain is broken for a week.

Checked locally with `shellcheck -x`, `actionlint`, and a stubbed harness covering the listing window, a window of zero, a failed commits listing, the cap, untested-only, failing-only, the default selection, an empty selection, a missing results file, and a digest failure.