### PR TITLE
fix: stop sharing image packages across Pythons

### DIFF
--- a/.github/docker/test-extensions/Dockerfile
+++ b/.github/docker/test-extensions/Dockerfile
@@ -53,18 +53,32 @@ ARG HOST_UID=1000
 ARG HOST_GID=1000
 RUN if [ -d /opt/tinytex ]; then chown -R ${HOST_UID}:${HOST_GID} /opt/tinytex; fi
 
+# uv keeps the interpreters it downloads under HOME by default, and the render
+# step gives every extension its own HOME, so the pinned interpreter would be
+# downloaded again for each of them. Hold it outside HOME instead. The mode is
+# the one /tmp uses: the render containers run under the host user, which is
+# not known here, and a container writes only to its own discarded layer.
+RUN install -d -m 1777 /opt/uv-python
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
+
 USER vscode
 
 # Python virtual environment with Jupyter and common packages.
-# The version is pinned instead of inherited from the base image: the render
-# scripts share these packages with a project venv only when the two Python
-# minor versions match, so a silent bump in the base image would withdraw them
-# from every extension at once. 3.13 is the version most extensions resolve to.
+# The version is pinned instead of resolved by uv: the render scripts share
+# these packages with a project venv only when the two Python minor versions
+# match, and uv picks the newest interpreter it can find, so an unpinned venv
+# would withdraw them from every extension the day a new release lands.
+# 3.13 is the version most extensions resolve to. deps-install.sh builds the
+# project venv on HARNESS_PYTHON too, unless the repository excludes it.
 ARG HARNESS_PYTHON=3.13
 ENV UV_LINK_MODE=copy
-RUN uv venv --python ${HARNESS_PYTHON} /home/vscode/.venv \
-    && . /home/vscode/.venv/bin/activate \
-    && uv pip install jupyter papermill matplotlib shinylive black
+ENV IMAGE_VENV=/home/vscode/.venv
+# deps-install.sh reads this list to replace the packages an extension loses
+# when its Python version differs from the image one.
+ENV IMAGE_BASELINE="jupyter papermill matplotlib shinylive black"
+RUN uv venv --python ${HARNESS_PYTHON} ${IMAGE_VENV} \
+    && . ${IMAGE_VENV}/bin/activate \
+    && uv pip install ${IMAGE_BASELINE}
 ENV HARNESS_PYTHON=${HARNESS_PYTHON}
-ENV VIRTUAL_ENV=/home/vscode/.venv
-ENV PATH="/home/vscode/.venv/bin:${PATH}"
+ENV VIRTUAL_ENV=${IMAGE_VENV}
+ENV PATH="${IMAGE_VENV}/bin:${PATH}"

--- a/.github/docker/test-extensions/Dockerfile
+++ b/.github/docker/test-extensions/Dockerfile
@@ -55,10 +55,16 @@ RUN if [ -d /opt/tinytex ]; then chown -R ${HOST_UID}:${HOST_GID} /opt/tinytex; 
 
 USER vscode
 
-# Python virtual environment with Jupyter and common packages
+# Python virtual environment with Jupyter and common packages.
+# The version is pinned instead of inherited from the base image: the render
+# scripts share these packages with a project venv only when the two Python
+# minor versions match, so a silent bump in the base image would withdraw them
+# from every extension at once. 3.13 is the version most extensions resolve to.
+ARG HARNESS_PYTHON=3.13
 ENV UV_LINK_MODE=copy
-RUN uv venv /home/vscode/.venv \
+RUN uv venv --python ${HARNESS_PYTHON} /home/vscode/.venv \
     && . /home/vscode/.venv/bin/activate \
     && uv pip install jupyter papermill matplotlib shinylive black
+ENV HARNESS_PYTHON=${HARNESS_PYTHON}
 ENV VIRTUAL_ENV=/home/vscode/.venv
 ENV PATH="/home/vscode/.venv/bin:${PATH}"

--- a/.github/scripts/test-extensions/deps-install.sh
+++ b/.github/scripts/test-extensions/deps-install.sh
@@ -26,38 +26,80 @@ detect_engines() {
 
 engines=$(detect_engines)
 
-# Create the project venv. When the repository declares no Python version,
-# match the image venv so render-inner.sh can share its packages; uv resolves
-# a declared version itself, and an explicit flag that contradicts it errors.
-create_project_venv() {
-	local args=(--clear)
-	if [[ -n "${HARNESS_PYTHON:-}" ]] && [[ ! -f pyproject.toml ]] && [[ ! -f .python-version ]]; then
-		args+=(--python "${HARNESS_PYTHON}")
+IMAGE_VENV="${IMAGE_VENV:-/home/vscode/.venv}"
+
+# Packages the image venv ships, published by the image itself so the two
+# cannot drift. render-inner.sh shares the image copies only when the two
+# Python versions match, so ensure_image_baseline replaces what a mismatch
+# withdraws. The default covers an image built before that variable existed.
+read -ra image_baseline <<<"${IMAGE_BASELINE:-jupyter papermill matplotlib shinylive black}"
+
+# The jupyter distribution is a metapackage that imports nothing, so probe the
+# modules the render actually needs from it.
+baseline_modules() {
+	if [[ "$1" == "jupyter" ]]; then
+		echo "ipykernel, nbclient, nbformat"
+	else
+		echo "$1"
 	fi
-	uv venv "${args[@]}" >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+}
+
+# A repository declares its Python version through .python-version or through
+# requires-python. uv only warns when an explicit version contradicts such a
+# declaration, and builds the environment anyway, so the flag must not be
+# passed here: the repository's own version is the one under test.
+declares_python_version() {
+	if [[ -f .python-version ]]; then
+		return 0
+	fi
+	if [[ -f pyproject.toml ]] && grep -Eq '^[[:space:]]*requires-python[[:space:]]*=' pyproject.toml; then
+		return 0
+	fi
+	return 1
+}
+
+# Create the project venv. uv picks the newest interpreter it can find when the
+# repository declares none, which leaves the image packages unshareable for no
+# reason, so build those environments on the image version instead.
+create_project_venv() {
+	if [[ -n "${HARNESS_PYTHON:-}" ]] && ! declares_python_version; then
+		if uv venv --clear --python "${HARNESS_PYTHON}" >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log"; then
+			return 0
+		fi
+		# The repository asked for nothing, so any interpreter will do: a
+		# missing image version must not fail the install.
+		echo "Python ${HARNESS_PYTHON} is unavailable for ${EXT_ID}; letting uv resolve the version." >>"${LOG_DIR}/stdout.log"
+	fi
+	uv venv --clear >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
 		echo "uv venv failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
 		exit 1
 	}
 }
 
-# render-inner.sh only shares the image venv site-packages with a project venv
-# built on the same Python minor version, so a project that pins another
-# version needs its own Jupyter stack to execute Python cells.
-ensure_jupyter_baseline() {
-	local venv_tag
+# Install the image baseline packages the project venv lacks, so a repository
+# on another Python version keeps the packages the share used to provide.
+# Packages the repository installed itself are left untouched.
+ensure_image_baseline() {
+	local venv_tag package
+	local missing=()
 	venv_tag=$(python3 -c 'import sys; print("python%d.%d" % sys.version_info[:2])')
-	if [[ -d "/home/vscode/.venv/lib/${venv_tag}/site-packages" ]]; then
+	if [[ -d "${IMAGE_VENV}/lib/${venv_tag}/site-packages" ]]; then
 		return 0
 	fi
 	if ! echo "${engines}" | grep -qx "jupyter"; then
 		return 0
 	fi
-	if python3 -c 'import ipykernel, nbclient, nbformat' 2>/dev/null; then
+	for package in "${image_baseline[@]}"; do
+		if ! python3 -c "import $(baseline_modules "${package}")" 2>/dev/null; then
+			missing+=("${package}")
+		fi
+	done
+	if [[ ${#missing[@]} -eq 0 ]]; then
 		return 0
 	fi
-	echo "Project venv Python (${venv_tag}) differs from the image venv for ${EXT_ID}; installing the Jupyter baseline." >>"${LOG_DIR}/stdout.log"
-	uv pip install jupyter papermill >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-		echo "Jupyter baseline install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+	echo "Project venv Python (${venv_tag}) differs from the image venv for ${EXT_ID}; installing ${missing[*]}." >>"${LOG_DIR}/stdout.log"
+	uv pip install "${missing[@]}" >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+		echo "Image baseline install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
 		exit 1
 	}
 }
@@ -203,7 +245,7 @@ for pkg in sorted({DISTRIBUTIONS.get(name, name) for name in third_party}):
 			else
 				echo "No additional Python packages to install." >>"${LOG_DIR}/stdout.log"
 			fi
-			ensure_jupyter_baseline
+			ensure_image_baseline
 		fi
 	fi
 fi
@@ -285,7 +327,7 @@ if [[ -f uv.lock ]] || [[ -f requirements.txt ]]; then
 			exit 1
 		}
 	fi
-	ensure_jupyter_baseline
+	ensure_image_baseline
 fi
 if [[ -f Project.toml ]] || [[ -f JuliaProject.toml ]]; then
 	echo "Installing Julia dependencies from Project.toml for ${EXT_ID}." >>"${LOG_DIR}/stdout.log"

--- a/.github/scripts/test-extensions/deps-install.sh
+++ b/.github/scripts/test-extensions/deps-install.sh
@@ -26,6 +26,42 @@ detect_engines() {
 
 engines=$(detect_engines)
 
+# Create the project venv. When the repository declares no Python version,
+# match the image venv so render-inner.sh can share its packages; uv resolves
+# a declared version itself, and an explicit flag that contradicts it errors.
+create_project_venv() {
+	local args=(--clear)
+	if [[ -n "${HARNESS_PYTHON:-}" ]] && [[ ! -f pyproject.toml ]] && [[ ! -f .python-version ]]; then
+		args+=(--python "${HARNESS_PYTHON}")
+	fi
+	uv venv "${args[@]}" >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+		echo "uv venv failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+		exit 1
+	}
+}
+
+# render-inner.sh only shares the image venv site-packages with a project venv
+# built on the same Python minor version, so a project that pins another
+# version needs its own Jupyter stack to execute Python cells.
+ensure_jupyter_baseline() {
+	local venv_tag
+	venv_tag=$(python3 -c 'import sys; print("python%d.%d" % sys.version_info[:2])')
+	if [[ -d "/home/vscode/.venv/lib/${venv_tag}/site-packages" ]]; then
+		return 0
+	fi
+	if ! echo "${engines}" | grep -qx "jupyter"; then
+		return 0
+	fi
+	if python3 -c 'import ipykernel, nbclient, nbformat' 2>/dev/null; then
+		return 0
+	fi
+	echo "Project venv Python (${venv_tag}) differs from the image venv for ${EXT_ID}; installing the Jupyter baseline." >>"${LOG_DIR}/stdout.log"
+	uv pip install jupyter papermill >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
+		echo "Jupyter baseline install failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+		exit 1
+	}
+}
+
 # A documentation website under docs/ is a separate project that documents the
 # extension rather than exercising it, and render-inner.sh keeps it out of the
 # render surface. Its dependencies are therefore not needed, unless the
@@ -72,10 +108,7 @@ if [[ ! -f uv.lock ]] && [[ ! -f requirements.txt ]]; then
 
 		if [[ "${has_python}" == "true" ]]; then
 			echo "Auto-detecting Python dependencies for ${EXT_ID} (jupyter engine, no lock file)." >>"${LOG_DIR}/stdout.log"
-			uv venv --clear >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-				echo "uv venv failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-				exit 1
-			}
+			create_project_venv
 			# shellcheck disable=SC1091 # created at runtime by uv venv
 			source .venv/bin/activate
 
@@ -170,6 +203,7 @@ for pkg in sorted({DISTRIBUTIONS.get(name, name) for name in third_party}):
 			else
 				echo "No additional Python packages to install." >>"${LOG_DIR}/stdout.log"
 			fi
+			ensure_jupyter_baseline
 		fi
 	fi
 fi
@@ -237,10 +271,7 @@ if [[ -f renv.lock ]]; then
 fi
 if [[ -f uv.lock ]] || [[ -f requirements.txt ]]; then
 	echo "Installing Python dependencies for ${EXT_ID}." >>"${LOG_DIR}/stdout.log"
-	uv venv --clear >>"${LOG_DIR}/stdout.log" 2>>"${LOG_DIR}/stderr.log" || {
-		echo "uv venv failed for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
-		exit 1
-	}
+	create_project_venv
 	# shellcheck disable=SC1091 # created at runtime by uv venv
 	source .venv/bin/activate
 	if [[ -f uv.lock ]]; then
@@ -254,6 +285,7 @@ if [[ -f uv.lock ]] || [[ -f requirements.txt ]]; then
 			exit 1
 		}
 	fi
+	ensure_jupyter_baseline
 fi
 if [[ -f Project.toml ]] || [[ -f JuliaProject.toml ]]; then
 	echo "Installing Julia dependencies from Project.toml for ${EXT_ID}." >>"${LOG_DIR}/stdout.log"

--- a/.github/scripts/test-extensions/render-inner.sh
+++ b/.github/scripts/test-extensions/render-inner.sh
@@ -8,20 +8,34 @@ set -euo pipefail
 
 # Activate local venv if created during dependency install.
 # Preserve access to the image-level venv site-packages so pre-installed
-# packages (jupyter, shinylive, pyyaml, etc.) remain importable.
+# packages (jupyter, shinylive, pyyaml, etc.) remain importable. The share is
+# a .pth file rather than PYTHONPATH: site.py appends the paths it reads from
+# a .pth file after the local site-packages, so the versions the repository
+# locked keep priority and the image venv only fills genuine gaps. It is also
+# limited to an image venv built on the same Python minor version: compiled
+# extension modules carry an interpreter-specific suffix, so sharing across
+# versions hides the local copy behind one the interpreter cannot import.
 IMAGE_VENV="/home/vscode/.venv"
 if [[ -f .venv/bin/activate ]]; then
-	image_sp=""
-	for sp in "${IMAGE_VENV}"/lib/python*/site-packages; do
-		if [[ -d "${sp}" ]]; then
-			image_sp="${sp}"
-			break
-		fi
-	done
 	# shellcheck disable=SC1091 # created at runtime by uv venv
 	source .venv/bin/activate
-	if [[ -n "${image_sp}" ]]; then
-		export PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${image_sp}"
+	if ! read -r venv_tag venv_purelib < <(
+		python3 -c 'import sys, sysconfig; print("python%d.%d" % sys.version_info[:2], sysconfig.get_paths()["purelib"])'
+	); then
+		echo "Could not inspect the project venv Python for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
+		exit 1
+	fi
+	image_sp="${IMAGE_VENV}/lib/${venv_tag}/site-packages"
+	if [[ -d "${image_sp}" ]]; then
+		printf '%s\n' "${image_sp}" >"${venv_purelib}/zz-image-venv.pth"
+	else
+		image_tags=""
+		for lib in "${IMAGE_VENV}"/lib/python*/; do
+			[[ -d "${lib}" ]] || continue
+			image_tags="${image_tags:+${image_tags}, }$(basename "${lib}")"
+		done
+		echo "Image venv (${image_tags:-none}) does not match the project venv (${venv_tag}) for ${EXT_ID}; its packages are not shared." \
+			>>"${LOG_DIR}/stdout.log"
 	fi
 fi
 

--- a/.github/scripts/test-extensions/render-inner.sh
+++ b/.github/scripts/test-extensions/render-inner.sh
@@ -15,27 +15,30 @@ set -euo pipefail
 # limited to an image venv built on the same Python minor version: compiled
 # extension modules carry an interpreter-specific suffix, so sharing across
 # versions hides the local copy behind one the interpreter cannot import.
-IMAGE_VENV="/home/vscode/.venv"
+IMAGE_VENV="${IMAGE_VENV:-/home/vscode/.venv}"
 if [[ -f .venv/bin/activate ]]; then
 	# shellcheck disable=SC1091 # created at runtime by uv venv
 	source .venv/bin/activate
-	if ! read -r venv_tag venv_purelib < <(
-		python3 -c 'import sys, sysconfig; print("python%d.%d" % sys.version_info[:2], sysconfig.get_paths()["purelib"])'
+	if ! read -r venv_tag venv_sitedir < <(
+		python3 -c 'import site, sys; print("python%d.%d" % sys.version_info[:2], site.getsitepackages()[0])'
 	); then
 		echo "Could not inspect the project venv Python for ${EXT_ID}." >>"${LOG_DIR}/stderr.log"
 		exit 1
 	fi
 	image_sp="${IMAGE_VENV}/lib/${venv_tag}/site-packages"
 	if [[ -d "${image_sp}" ]]; then
-		printf '%s\n' "${image_sp}" >"${venv_purelib}/zz-image-venv.pth"
+		printf '%s\n' "${image_sp}" >"${venv_sitedir}/zz-image-venv.pth"
 	else
 		image_tags=""
 		for lib in "${IMAGE_VENV}"/lib/python*/; do
 			[[ -d "${lib}" ]] || continue
 			image_tags="${image_tags:+${image_tags}, }$(basename "${lib}")"
 		done
-		echo "Image venv (${image_tags:-none}) does not match the project venv (${venv_tag}) for ${EXT_ID}; its packages are not shared." \
-			>>"${LOG_DIR}/stdout.log"
+		# Also on the job log: this decides which packages the render can
+		# import, so it must be readable without opening the extension log.
+		mismatch="Image venv (${image_tags:-none}) does not match the project venv (${venv_tag}) for ${EXT_ID}; its packages are not shared."
+		echo "${mismatch}"
+		echo "${mismatch}" >>"${LOG_DIR}/stdout.log"
 	fi
 fi
 


### PR DESCRIPTION
The render step exported the image venv `site-packages` through `PYTHONPATH`. Python places those entries ahead of the active environment on `sys.path`, so the image copies replaced every package an extension had locked, and a compiled extension module carries an interpreter-specific suffix, so an extension pinning a different Python minor version could not import the shared tree at all. `mcanouil/quarto-collapse-output` pins `==3.13.*` against a 3.14 image venv and fails on `ModuleNotFoundError: No module named 'rpds.rpds'`; `peter-gy/quarto-gradio` fails the same way.

`render-inner.sh` now writes the shared path into a `.pth` file inside the project venv instead. `site.py` appends those paths after the local `site-packages`, so the versions an extension locked keep priority and the image venv only fills gaps. The share applies only when both venvs are built on the same Python minor version, and a mismatch is written to the extension's `stdout.log`.

`deps-install.sh` covers what the guard withdraws. `create_project_venv` builds the project venv on the image Python when the repository declares no version of its own, and `ensure_jupyter_baseline` installs `jupyter` and `papermill` into the project venv when the versions do differ, the repository uses the jupyter engine, and it has not locked the stack itself.

The `Dockerfile` pins the image venv interpreter through a `HARNESS_PYTHON` build argument, exported as an environment variable so the scripts read it from the image. The stored logs hold both `python3.13` and `python3.14` paths, so this version has already drifted once unnoticed.

Verified locally with shellcheck, shfmt, and real 3.13 and 3.14 environments: the previous logic reproduces the reported error and silently downgrades a locked package, and the new logic skips the injection on a mismatch and keeps the project version ahead of the image copy on a match.

Touching the `Dockerfile` changes its hash, so the next scheduled run rebuilds both channel images before rendering anything.