### PR TITLE
feat: assert that an extension works, not that its render exited zero

### DIFF
--- a/.github/scripts/test-extensions/build-matrix.sh
+++ b/.github/scripts/test-extensions/build-matrix.sh
@@ -145,10 +145,9 @@ entries_phase_a=$(echo "${extensions_json}" | jq -c '
       else empty
       end
     )
-  # A template or example is never classified, so give it the mode
-  # explicitly rather than leaving it unset.
-  | map(. + {test_mode: "render-only"})
 ')
+# A template or example is never classified, so give it the mode explicitly.
+entries_phase_a=$(echo "${entries_phase_a}" | stamp_default_test_mode)
 
 phase_b_entries_file=$(mktemp)
 skipped_file=$(mktemp)

--- a/.github/scripts/test-extensions/build-matrix.sh
+++ b/.github/scripts/test-extensions/build-matrix.sh
@@ -145,6 +145,9 @@ entries_phase_a=$(echo "${extensions_json}" | jq -c '
       else empty
       end
     )
+  # A template or example is never classified, so give it the mode
+  # explicitly rather than leaving it unset.
+  | map(. + {test_mode: "render-only"})
 ')
 
 phase_b_entries_file=$(mktemp)
@@ -216,7 +219,11 @@ for ((idx = 0; idx < candidate_count; idx++)); do
     continue
   fi
 
-  if entry_json=$(classify_extension_tree "" <"${trees_dir}/${idx}.tree"); then
+  tree=$(cat "${trees_dir}/${idx}.tree")
+  if entry_json=$(printf '%s\n' "${tree}" | classify_extension_tree ""); then
+    # Reuse the tree already read above rather than fetching it again.
+    mode=$(printf '%s\n' "${tree}" | detect_test_mode)
+    entry_json=$(printf '%s' "${entry_json}" | jq -c --arg m "${mode}" '. + {test_mode: $m}')
     jq -cn --arg id "${id}" --argjson e "${entry_json}" '{id: $id} + $e' >>"${phase_b_entries_file}"
     continue
   fi

--- a/.github/scripts/test-extensions/classify-extension.sh
+++ b/.github/scripts/test-extensions/classify-extension.sh
@@ -138,3 +138,12 @@ detect_test_mode() {
 
 	echo "conformance"
 }
+
+# Stamp the default test mode onto a JSON array of entries on stdin, printing
+# the array back out. A template or example entry is never classified, so its
+# mode is stamped here rather than inherited from whatever a previous entry
+# carried; kept separate from build-matrix.sh so the stamping itself can be
+# tested. Does not overwrite a test_mode an entry already carries.
+stamp_default_test_mode() {
+	jq -c 'map(. + {test_mode: (.test_mode // "render-only")})'
+}

--- a/.github/scripts/test-extensions/classify-extension.sh
+++ b/.github/scripts/test-extensions/classify-extension.sh
@@ -100,6 +100,11 @@ classify_extension_tree() {
 # Decide which test mode an entry runs in, from a repository tree on stdin.
 # Prints one of: suite, schema, conformance, render-only.
 #
+# Only build-matrix.sh calls this, so only the monthly sweep runs the
+# framework. check-extensions/preflight-render.sh sources this file for
+# classify_extension_tree and stays a plain render: a pull request check
+# gates one new entry, and the sweep is where every entry is asserted.
+#
 # Paths only, because build-matrix.sh works from the trees API and has no file
 # contents. A schema this cannot tell is v1 is handled at run time: the
 # framework skips it, the run is all skips, and the caller falls back to the

--- a/.github/scripts/test-extensions/classify-extension.sh
+++ b/.github/scripts/test-extensions/classify-extension.sh
@@ -102,8 +102,10 @@ classify_extension_tree() {
 #
 # Only build-matrix.sh calls this, so only the monthly sweep runs the
 # framework. check-extensions/preflight-render.sh sources this file for
-# classify_extension_tree and stays a plain render: a pull request check
-# gates one new entry, and the sweep is where every entry is asserted.
+# classify_extension_tree and runs the same render harness, but builds its
+# own batch entries without a test_mode, so every one of them defaults to
+# render-only: a pull request check gates one new entry, and the sweep is
+# where every entry is asserted.
 #
 # Paths only, because build-matrix.sh works from the trees API and has no file
 # contents. A schema this cannot tell is v1 is handled at run time: the

--- a/.github/scripts/test-extensions/classify-extension.sh
+++ b/.github/scripts/test-extensions/classify-extension.sh
@@ -96,3 +96,45 @@ classify_extension_tree() {
 
 	return 1
 }
+
+# Decide which test mode an entry runs in, from a repository tree on stdin.
+# Prints one of: suite, schema, conformance, render-only.
+#
+# Paths only, because build-matrix.sh works from the trees API and has no file
+# contents. A schema this cannot tell is v1 is handled at run time: the
+# framework skips it, the run is all skips, and the caller falls back to the
+# render it would have done anyway.
+detect_test_mode() {
+	local tree
+	tree=$(cat)
+
+	# The repository's own extension, not an installed copy under docs/ or a
+	# staged one under tests/. This mirrors what the framework itself
+	# discovers.
+	local manifest
+	manifest=$(printf '%s\n' "${tree}" | grep -E '^_extensions/[^/]+/_extension\.ya?ml$' || true)
+	if [[ -z "${manifest}" ]]; then
+		echo "render-only"
+		return 0
+	fi
+
+	local tests_project tests_documents
+	tests_project=$(printf '%s\n' "${tree}" | grep -E '^tests/_quarto\.ya?ml$' || true)
+	# A generated, staged or result document is not an authored test.
+	tests_documents=$(printf '%s\n' "${tree}" |
+		grep -E '^tests/.*\.qmd$' |
+		grep -vE '^tests/(_extensions|generated|_results|_output)/' || true)
+	if [[ -n "${tests_project}" ]] && [[ -n "${tests_documents}" ]]; then
+		echo "suite"
+		return 0
+	fi
+
+	local schema
+	schema=$(printf '%s\n' "${tree}" | grep -E '^_extensions/[^/]+/_schema\.(json|ya?ml)$' || true)
+	if [[ -n "${schema}" ]]; then
+		echo "schema"
+		return 0
+	fi
+
+	echo "conformance"
+}

--- a/.github/scripts/test-extensions/publish-results.sh
+++ b/.github/scripts/test-extensions/publish-results.sh
@@ -83,7 +83,7 @@ jq -c --arg d "${today}" --slurpfile cur "${current_run_file}" '
 
 skipped_count=$(echo "${skipped_json}" | jq 'length')
 
-read -r run_total run_pass run_fail run_skip run_fail_deps run_fail_render run_fail_other < <(
+read -r run_total run_pass run_fail run_skip run_fail_deps run_fail_render run_fail_extension_test run_fail_other < <(
   jq -r '
     . as $all
     | ($all | [.[].id] | unique | length) as $run_total
@@ -93,11 +93,15 @@ read -r run_total run_pass run_fail run_skip run_fail_deps run_fail_render run_f
     | ([$groups[] | select(all(.status == "skip"))] | length) as $run_skip
     | ([$groups[] | select(any(.status == "fail"))
         | [.[] | select(.status == "fail") | .stage // ""]
-        | if any(. == "deps") then "deps" elif any(. == "render") then "render" else "other" end]) as $fail_stages
+        | if any(. == "deps") then "deps"
+          elif any(. == "render") then "render"
+          elif any(. == "extension-test") then "extension-test"
+          else "other" end]) as $fail_stages
     | ($fail_stages | map(select(. == "deps")) | length) as $run_fail_deps
     | ($fail_stages | map(select(. == "render")) | length) as $run_fail_render
+    | ($fail_stages | map(select(. == "extension-test")) | length) as $run_fail_extension_test
     | ($fail_stages | map(select(. == "other")) | length) as $run_fail_other
-    | [$run_total, $run_pass, $run_fail, $run_skip, $run_fail_deps, $run_fail_render, $run_fail_other] | @tsv
+    | [$run_total, $run_pass, $run_fail, $run_skip, $run_fail_deps, $run_fail_render, $run_fail_extension_test, $run_fail_other] | @tsv
   ' "${current_run_file}"
 )
 
@@ -131,7 +135,7 @@ skipped_list=$(echo "${skipped_json}" | jq -r '.[] | "- \(.)"')
   echo ""
   echo "- **Extensions tested:** ${run_total}"
   echo "- **Pass:** ${run_pass}"
-  echo "- **Fail:** ${run_fail} (dependencies: ${run_fail_deps}, render: ${run_fail_render}, other: ${run_fail_other})"
+  echo "- **Fail:** ${run_fail} (dependencies: ${run_fail_deps}, render: ${run_fail_render}, extension test: ${run_fail_extension_test}, other: ${run_fail_other})"
   echo "- **Skipped (repository not publicly accessible):** ${run_skip}"
   echo "- **Skipped (no renderable content found):** ${skipped_count}"
   echo ""

--- a/.github/scripts/test-extensions/publish-results.sh
+++ b/.github/scripts/test-extensions/publish-results.sh
@@ -72,7 +72,9 @@ jq -c --arg d "${today}" --slurpfile cur "${current_run_file}" '
               log: $e.log,
               date: $d,
               stage: (($e.stage // "") | tostring),
-              failure_reason: (($e.failure_reason // "") | tostring)
+              failure_reason: (($e.failure_reason // "") | tostring),
+              test_mode: ($e.test_mode // "render-only"),
+              cases: ($e.cases // {total: 0, pass: 0, fail: 0, skip: 0})
             }]
         )
     )

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -187,6 +187,21 @@ framework_decides() {
 	fi
 }
 
+# Whether the framework's verdict overrides the render's status.
+#
+# The framework may add a failure the render missed, but must never erase one
+# the render already found: a clone, policy, dependency or render failure is a
+# fact about the entry that a later, decoupled probe cannot disprove. So the
+# override only ever applies when the render itself was clean going in.
+override_applies() {
+	local pre_status="$1" mode="$2" verdict="$3" fail_count="$4" rendered="$5"
+	if [[ "${pre_status}" != "pass" ]]; then
+		echo "no"
+		return 0
+	fi
+	framework_decides "${mode}" "${verdict}" "${fail_count}" "${rendered}"
+}
+
 render_extension() {
 	local i="$1"
 	local shard="${2:-0}"
@@ -288,6 +303,7 @@ render_extension() {
 		fi
 	fi
 
+	local pre_framework_status="${status}"
 	local test_mode fw_status fw_total fw_pass fw_fail fw_skip fw_rendered
 	test_mode=$(jq -r ".[${i}].ext.test_mode // \"render-only\"" clone-manifest.json)
 
@@ -304,7 +320,7 @@ render_extension() {
 		)
 	fi
 
-	if [[ "$(framework_decides "${test_mode}" "${fw_status}" "${fw_fail}" "${fw_rendered}")" == "yes" ]]; then
+	if [[ "$(override_applies "${pre_framework_status}" "${test_mode}" "${fw_status}" "${fw_fail}" "${fw_rendered}")" == "yes" ]]; then
 		if [[ "${fw_status}" == "fail" ]]; then
 			status="fail"
 			stage="extension-test"

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -412,9 +412,15 @@ if ((${#result_files[@]} > 0)); then
 else
 	echo '[]' >results.json
 fi
-# A render was executed exactly when the extension passed or failed at the
-# render stage (earlier stages never reach quarto render).
-render_count=$(jq '[.[] | select(.status == "pass" or .stage == "render")] | length' results.json)
+# Count entries for which a render was executed: a pass, a failure at the
+# render stage, or a failure at the extension-test stage (earlier stages
+# never reach quarto render; an extension-test failure means the framework
+# decided the entry after render_extension had already run the render).
+count_renders() {
+	jq '[.[] | select(.status == "pass" or .stage == "render" or .stage == "extension-test")] | length' "$1"
+}
+
+render_count=$(count_renders results.json)
 
 if [[ "${ext_count}" -gt 0 ]] && [[ "${render_count}" -eq 0 ]]; then
 	echo "::error::No quarto render was executed for ${ext_count} extensions."

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -38,10 +38,19 @@ docker_run_render() {
 	shift 6
 	local cache_mount=()
 	# The shared cache is a read-write surface across repositories within this
-	# job, so only a caller that actually needs packages mounts it.
-	if [[ "${mount_cache}" == "yes" ]]; then
+	# job, so only a caller that actually needs packages mounts it. A case
+	# statement, rather than an if, means a typo in a caller's mount_cache
+	# argument fails loudly instead of silently falling through to "no cache".
+	case "${mount_cache}" in
+	yes)
 		cache_mount=(-v "${cache_root}:/cache")
-	fi
+		;;
+	no) ;;
+	*)
+		echo "::error::Invalid mount_cache value '${mount_cache}'. Expected 'yes' or 'no'." >&2
+		return 1
+		;;
+	esac
 	timeout --kill-after=30 "${run_timeout}" docker run --rm -i \
 		--user "${DOCKER_USER}" \
 		"${DOCKER_SECURITY_OPTS[@]}" \

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -157,12 +157,17 @@ framework_verdict() {
 		printf 'none\t0\t0\t0\t0\t0\n'
 		return 0
 	fi
+	# Only a bounded enum and four integers may reach the published catalogue.
+	# The JSON is written inside the container by the repository's own
+	# extension, so `numbers` coerces anything a repository puts there other
+	# than a number (a string, a boolean, an array) down to the default,
+	# rather than letting it travel through @tsv and later --argjson.
 	jq -r '
 		[(.status // "none"),
-		 (.summary.total // 0), (.summary.pass // 0),
-		 (.summary.fail // 0), (.summary.skip // 0),
+		 (.summary.total | numbers // 0), (.summary.pass | numbers // 0),
+		 (.summary.fail | numbers // 0), (.summary.skip | numbers // 0),
 		 ([(.layers.render // {}), (.layers.smoke // {})]
-		  | map((.pass // 0) + (.fail // 0)) | add)]
+		  | map((.pass | numbers // 0) + (.fail | numbers // 0)) | add)]
 		| @tsv
 	' "${json}" 2>/dev/null || printf 'none\t0\t0\t0\t0\t0\n'
 }

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -158,6 +158,35 @@ framework_verdict() {
 	' "${json}" 2>/dev/null || printf 'none\t0\t0\t0\t0\t0'
 }
 
+# Whether the framework's verdict replaces the render's.
+#
+# Replacing the render must never mean checking less, so three things must all
+# hold: the mode is one where the framework renders, it reached a verdict, and
+# it actually decided at least one rendering case. The third is not implied by
+# the second. An extension contributing only a project type passes conformance
+# and skips its only smoke case, so the run reports pass while having rendered
+# nothing; taking that verdict would mark the entry green and drop the render
+# it gets today.
+framework_decides() {
+	local mode="$1" verdict="$2" fail_count="$3" rendered="$4"
+	case "${mode}" in
+	suite | schema) ;;
+	*)
+		echo "no"
+		return 0
+		;;
+	esac
+	if [[ "${rendered}" -lt 1 ]]; then
+		echo "no"
+		return 0
+	fi
+	if [[ "${verdict}" == "pass" ]] || { [[ "${verdict}" == "fail" ]] && [[ "${fail_count}" -gt 0 ]]; }; then
+		echo "yes"
+	else
+		echo "no"
+	fi
+}
+
 render_extension() {
 	local i="$1"
 	local shard="${2:-0}"
@@ -259,6 +288,36 @@ render_extension() {
 		fi
 	fi
 
+	local test_mode fw_status fw_total fw_pass fw_fail fw_skip fw_rendered
+	test_mode=$(jq -r ".[${i}].ext.test_mode // \"render-only\"" clone-manifest.json)
+
+	fw_status="none"
+	fw_total=0
+	fw_pass=0
+	fw_fail=0
+	fw_skip=0
+	fw_rendered=0
+	if [[ "${test_mode}" != "render-only" ]] && [[ "${status}" != "skip" ]]; then
+		run_framework "${test_mode}" "${workdir}" "${log_dir}" "${render_dir}" "${shard}"
+		IFS=$'\t' read -r fw_status fw_total fw_pass fw_fail fw_skip fw_rendered < <(
+			framework_verdict "${log_dir}/extension-test.json"
+		)
+	fi
+
+	if [[ "$(framework_decides "${test_mode}" "${fw_status}" "${fw_fail}" "${fw_rendered}")" == "yes" ]]; then
+		if [[ "${fw_status}" == "fail" ]]; then
+			status="fail"
+			stage="extension-test"
+			# Bounded on purpose: the detail is repository-derived text and
+			# stays in the log rather than entering the published catalogue.
+			failure_reason="cases-failed"
+		else
+			status="pass"
+			stage=""
+			failure_reason=""
+		fi
+	fi
+
 	# Copy render logs to log directory
 	find "${workdir}" -maxdepth 1 -name '*.log' -not -name 'stdout.log' -not -name 'stderr.log' -type f -exec cp --no-dereference {} "${log_dir}/" \; 2>/dev/null || true
 
@@ -281,7 +340,12 @@ render_extension() {
 		--arg qc "${QUARTO_CHANNEL}" \
 		--arg st "${stage}" \
 		--arg fr "${failure_reason}" \
-		'{id: $id, type: $t, status: $s, log: $l, quarto_version: $qv, quarto_channel: $qc, stage: $st, failure_reason: $fr}' \
+		--arg test_mode "${test_mode}" \
+		--argjson cases "$(jq -cn \
+			--argjson total "${fw_total}" --argjson pass "${fw_pass}" \
+			--argjson fail "${fw_fail}" --argjson skip "${fw_skip}" \
+			'{total: $total, pass: $pass, fail: $fail, skip: $skip}')" \
+		'{id: $id, type: $t, status: $s, log: $l, quarto_version: $qv, quarto_channel: $qc, stage: $st, failure_reason: $fr, test_mode: $test_mode, cases: $cases}' \
 		>"${results_dir}/${i}.json"
 }
 

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -198,15 +198,21 @@ framework_verdict() {
 	fi
 	# Only a bounded enum and four integers may reach the published catalogue.
 	# The JSON is written inside the container by the repository's own
-	# extension, so `numbers` coerces anything a repository puts there other
-	# than a number (a string, a boolean, an array) down to the default,
-	# rather than letting it travel through @tsv and later --argjson.
+	# extension, so a repository can put anything there. `count` coerces a
+	# string, a boolean or an array down to the default, and rounds what is
+	# left into a whole number within range: `numbers` alone still admits a
+	# fraction, a negative and a huge exponent, all of which would travel
+	# through @tsv and later --argjson into a field the design describes as a
+	# bounded integer. The ceiling is far above any real run, which
+	# --max-generated caps at a few dozen cases.
 	jq -r '
+		def count: (numbers // 0) | floor
+			| if . < 0 then 0 elif . > 1000000 then 1000000 else . end;
 		[(.status // "none"),
-		 (.summary.total | numbers // 0), (.summary.pass | numbers // 0),
-		 (.summary.fail | numbers // 0), (.summary.skip | numbers // 0),
+		 (.summary.total | count), (.summary.pass | count),
+		 (.summary.fail | count), (.summary.skip | count),
 		 ([(.layers.render // {}), (.layers.smoke // {})]
-		  | map((.pass | numbers // 0) + (.fail | numbers // 0)) | add)]
+		  | map((.pass | count) + (.fail | count)) | add)]
 		| @tsv
 	' "${json}" 2>/dev/null || printf 'none\t0\t0\t0\t0\t0\n'
 }

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -83,12 +83,29 @@ readonly FRAMEWORK_RUNNER="${FRAMEWORK_DIR}/_extensions/extension-test/run.lua"
 readonly FRAMEWORK_MAX_GENERATED=40
 readonly FRAMEWORK_TIMEOUT=600
 
+# Whether any entry in this batch will call the framework at all.
+framework_required() {
+	local manifest="$1"
+	if jq -e '[.[] | .ext.test_mode // "render-only"] | any(. != "render-only")' \
+		"${manifest}" >/dev/null 2>&1; then
+		echo "yes"
+	else
+		echo "no"
+	fi
+}
+
 # docker_run_render's caller swallows a non-zero exit with `|| true`, so a
 # layout change at a future framework tag that moves or renames the runner
 # would otherwise be silent: every framework run would quietly fail closed
 # and every entry would fall back to the render. Fail loudly instead, once,
 # before any extension is processed.
-if [[ ! -f "${FRAMEWORK_RUNNER}" ]]; then
+#
+# Only for a batch that needs it. check-extensions/preflight-render.sh runs
+# this script for a pull request, its workflow does not check the framework
+# out, and it turns a non-zero exit into a warning. An unconditional guard
+# there aborts before the first entry renders, leaves results.json unwritten,
+# and lets a blocking preflight report no failure at all.
+if [[ "$(framework_required clone-manifest.json)" == "yes" ]] && [[ ! -f "${FRAMEWORK_RUNNER}" ]]; then
 	echo "::error::Framework runner not found at ${FRAMEWORK_RUNNER}."
 	exit 1
 fi

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -83,6 +83,16 @@ readonly FRAMEWORK_RUNNER="${FRAMEWORK_DIR}/_extensions/extension-test/run.lua"
 readonly FRAMEWORK_MAX_GENERATED=40
 readonly FRAMEWORK_TIMEOUT=600
 
+# docker_run_render's caller swallows a non-zero exit with `|| true`, so a
+# layout change at a future framework tag that moves or renames the runner
+# would otherwise be silent: every framework run would quietly fail closed
+# and every entry would fall back to the render. Fail loudly instead, once,
+# before any extension is processed.
+if [[ ! -f "${FRAMEWORK_RUNNER}" ]]; then
+	echo "::error::Framework runner not found at ${FRAMEWORK_RUNNER}."
+	exit 1
+fi
+
 # Run the pinned framework against one clone, writing its JSON into the log
 # directory so it travels with the logs the entry already publishes.
 #

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -145,7 +145,7 @@ run_framework() {
 framework_verdict() {
 	local json="$1"
 	if [[ ! -s "${json}" ]]; then
-		printf 'none\t0\t0\t0\t0\t0'
+		printf 'none\t0\t0\t0\t0\t0\n'
 		return 0
 	fi
 	jq -r '
@@ -155,7 +155,7 @@ framework_verdict() {
 		 ([(.layers.render // {}), (.layers.smoke // {})]
 		  | map((.pass // 0) + (.fail // 0)) | add)]
 		| @tsv
-	' "${json}" 2>/dev/null || printf 'none\t0\t0\t0\t0\t0'
+	' "${json}" 2>/dev/null || printf 'none\t0\t0\t0\t0\t0\n'
 }
 
 # Whether the framework's verdict replaces the render's.
@@ -315,9 +315,12 @@ render_extension() {
 	fw_rendered=0
 	if [[ "${test_mode}" != "render-only" ]] && [[ "${status}" != "skip" ]]; then
 		run_framework "${test_mode}" "${workdir}" "${log_dir}" "${render_dir}" "${shard}"
+		# The fallback branches of framework_verdict always emit a trailing
+		# newline, but `|| true` keeps this shard alive even if a future change
+		# to that contract lets a delimiter-less read hit EOF again.
 		IFS=$'\t' read -r fw_status fw_total fw_pass fw_fail fw_skip fw_rendered < <(
 			framework_verdict "${log_dir}/extension-test.json"
-		)
+		) || true
 	fi
 
 	if [[ "$(override_applies "${pre_framework_status}" "${test_mode}" "${fw_status}" "${fw_fail}" "${fw_rendered}")" == "yes" ]]; then

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -34,8 +34,14 @@ for ((w = 0; w < RENDER_CONCURRENCY; w++)); do
 done
 
 docker_run_render() {
-	local run_timeout="$1" workdir="$2" log_dir="$3" render_dir="$4" shard="$5"
-	shift 5
+	local run_timeout="$1" workdir="$2" log_dir="$3" render_dir="$4" shard="$5" mount_cache="$6"
+	shift 6
+	local cache_mount=()
+	# The shared cache is a read-write surface across repositories within this
+	# job, so only a caller that actually needs packages mounts it.
+	if [[ "${mount_cache}" == "yes" ]]; then
+		cache_mount=(-v "${cache_root}:/cache")
+	fi
 	timeout --kill-after=30 "${run_timeout}" docker run --rm -i \
 		--user "${DOCKER_USER}" \
 		"${DOCKER_SECURITY_OPTS[@]}" \
@@ -53,12 +59,103 @@ docker_run_render() {
 		-e UV_CACHE_DIR="/cache/uv" \
 		-e JULIA_DEPOT_PATH="/cache/julia:" \
 		-e R_LIBS_USER="/cache/r-lib-${shard}" \
-		-v "${cache_root}:/cache" \
+		"${cache_mount[@]}" \
 		-v "${workdir}:${workdir}" \
 		-v "${log_dir}:${log_dir}" \
 		-w "${render_dir}" \
 		render-image \
 		bash
+}
+
+readonly FRAMEWORK_DIR="${GITHUB_WORKSPACE}/extension-test"
+readonly FRAMEWORK_RUNNER="${FRAMEWORK_DIR}/_extensions/extension-test/run.lua"
+# A catalogue sweep must finish, and a generated document per shortcode per
+# format grows with the extension rather than with the catalogue.
+readonly FRAMEWORK_MAX_GENERATED=40
+readonly FRAMEWORK_TIMEOUT=600
+
+# Run the pinned framework against one clone, writing its JSON into the log
+# directory so it travels with the logs the entry already publishes.
+#
+# `suite` renders the repository's own documents and so keeps the dependency
+# cache. `schema` and `conformance` render only documents the framework
+# generates, which are markdown with shortcode invocations and no executable
+# cells, so they need no packages and mount no cache: that keeps them out of
+# the one surface shared between repositories.
+run_framework() {
+	local mode="$1" workdir="$2" log_dir="$3" render_dir="$4" shard="$5"
+	local tests_dir layers mount_cache
+
+	case "${mode}" in
+	suite)
+		tests_dir="${render_dir}/tests"
+		layers=(--layer conformance --layer render --layer smoke)
+		mount_cache="yes"
+		;;
+	schema)
+		# The catalogue supplies the project, so the repository's own
+		# tests/_quarto.yml is never read and none of its render scripts run.
+		tests_dir="${workdir}/framework-tests"
+		install -d -m 700 "${tests_dir}"
+		printf 'project:\n  type: default\n  output-dir: _output\n' >"${tests_dir}/_quarto.yml"
+		layers=(--layer conformance --layer smoke)
+		mount_cache="no"
+		;;
+	conformance)
+		tests_dir="${workdir}/framework-tests"
+		install -d -m 700 "${tests_dir}"
+		printf 'project:\n  type: default\n  output-dir: _output\n' >"${tests_dir}/_quarto.yml"
+		layers=(--layer conformance)
+		mount_cache="no"
+		;;
+	*)
+		return 0
+		;;
+	esac
+
+	docker_run_render "${FRAMEWORK_TIMEOUT}" "${workdir}" "${log_dir}" "${render_dir}" "${shard}" "${mount_cache}" \
+		-v "${FRAMEWORK_DIR}:${FRAMEWORK_DIR}:ro" \
+		<<-EOF || true
+			set -uo pipefail
+			quarto pandoc lua "${FRAMEWORK_RUNNER}" \
+				--root "${render_dir}" \
+				--tests "${tests_dir}" \
+				--json "${log_dir}/extension-test.json" \
+				--tap /dev/null \
+				--quiet \
+				--max-generated ${FRAMEWORK_MAX_GENERATED} \
+				${layers[*]}
+		EOF
+}
+
+# Read the framework's own verdict out of its JSON.
+#
+# The exit code is not consulted on purpose: an all-skip run exits 0 and is
+# otherwise indistinguishable from a clean one, and this is the difference the
+# caller needs in order to decide whether to fall back to the render.
+#
+# `rendered` counts the cases the rendering layers actually decided, which is
+# not the same as the run passing. An extension contributing only a project
+# type passes conformance and skips its one smoke case, because generate.lua
+# names a contributed project type as a gap rather than half-generating it. It
+# would otherwise be recorded as a pass having rendered nothing.
+#
+# Prints: status<TAB>total<TAB>pass<TAB>fail<TAB>skip<TAB>rendered, where
+# status is `none` when there is nothing readable.
+framework_verdict() {
+	local json="$1"
+	if [[ ! -s "${json}" ]]; then
+		printf 'none\t0\t0\t0\t0\t0'
+		return 0
+	fi
+	jq -r '
+		[(.status // "none"),
+		 (.summary.total // 0), (.summary.pass // 0),
+		 (.summary.fail // 0), (.summary.skip // 0),
+		 ([(.layers.render // {}), (.layers.smoke // {})]
+		  | map((.pass // 0) + (.fail // 0)) | add)]
+		| @tsv
+	' "${json}" 2>/dev/null || printf 'none\t0\t0\t0\t0\t0'
 }
 
 render_extension() {
@@ -113,7 +210,7 @@ render_extension() {
 			fi
 			echo "Dependency install phase for ${id}: ${dep_sources[*]}" >>"${log_dir}/stdout.log"
 			run_dep_install() {
-				docker_run_render 600 "${workdir}" "${log_dir}" "${render_dir}" "${shard}" \
+				docker_run_render 600 "${workdir}" "${log_dir}" "${render_dir}" "${shard}" yes \
 					-e EXT_ID="${id}" \
 					-e LOG_DIR="${log_dir}" \
 					<"${SCRIPT_DIR}/deps-install.sh"
@@ -144,7 +241,7 @@ render_extension() {
 		# Phase B: Render
 		if [[ "${status}" == "pass" ]]; then
 			render_rc=0
-			docker_run_render 300 "${workdir}" "${log_dir}" "${render_dir}" "${shard}" \
+			docker_run_render 300 "${workdir}" "${log_dir}" "${render_dir}" "${shard}" yes \
 				-e EXT_TYPE="${ext_type}" \
 				-e EXT_ID="${id}" \
 				-e WORKDIR="${workdir}" \

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -111,21 +111,18 @@ run_framework() {
 		layers=(--layer conformance --layer render --layer smoke)
 		mount_cache="yes"
 		;;
-	schema)
+	schema | conformance)
 		# The catalogue supplies the project, so the repository's own
 		# tests/_quarto.yml is never read and none of its render scripts run.
 		tests_dir="${workdir}/framework-tests"
 		install -d -m 700 "${tests_dir}"
 		printf 'project:\n  type: default\n  output-dir: _output\n' >"${tests_dir}/_quarto.yml"
-		layers=(--layer conformance --layer smoke)
 		mount_cache="no"
-		;;
-	conformance)
-		tests_dir="${workdir}/framework-tests"
-		install -d -m 700 "${tests_dir}"
-		printf 'project:\n  type: default\n  output-dir: _output\n' >"${tests_dir}/_quarto.yml"
-		layers=(--layer conformance)
-		mount_cache="no"
+		if [[ "${mode}" == "schema" ]]; then
+			layers=(--layer conformance --layer smoke)
+		else
+			layers=(--layer conformance)
+		fi
 		;;
 	*)
 		return 0
@@ -134,9 +131,9 @@ run_framework() {
 
 	# A repository that has already failed the dependency source policy or a
 	# dependency install has not earned write access to a cache shared with
-	# every other repository in this job. This costs nothing real: override_
-	# applies already refuses a non-pass pre-status, so this run's verdict was
-	# never going to be used anyway.
+	# every other repository in this job. This costs nothing real, because
+	# override_applies already refuses a non-pass pre-status, so this run's
+	# verdict was never going to be used anyway.
 	if [[ "${pre_status}" != "pass" ]]; then
 		mount_cache="no"
 	fi
@@ -393,11 +390,11 @@ render_extension() {
 		--arg st "${stage}" \
 		--arg fr "${failure_reason}" \
 		--arg test_mode "${test_mode}" \
-		--argjson cases "$(jq -cn \
-			--argjson total "${fw_total}" --argjson pass "${fw_pass}" \
-			--argjson fail "${fw_fail}" --argjson skip "${fw_skip}" \
-			'{total: $total, pass: $pass, fail: $fail, skip: $skip}')" \
-		'{id: $id, type: $t, status: $s, log: $l, quarto_version: $qv, quarto_channel: $qc, stage: $st, failure_reason: $fr, test_mode: $test_mode, cases: $cases}' \
+		--argjson fw_total "${fw_total}" \
+		--argjson fw_pass "${fw_pass}" \
+		--argjson fw_fail "${fw_fail}" \
+		--argjson fw_skip "${fw_skip}" \
+		'{id: $id, type: $t, status: $s, log: $l, quarto_version: $qv, quarto_channel: $qc, stage: $st, failure_reason: $fr, test_mode: $test_mode, cases: {total: $fw_total, pass: $fw_pass, fail: $fw_fail, skip: $fw_skip}}' \
 		>"${results_dir}/${i}.json"
 }
 

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -93,6 +93,22 @@ if [[ ! -f "${FRAMEWORK_RUNNER}" ]]; then
 	exit 1
 fi
 
+# Whether the framework runs for this entry at all.
+#
+# Only where its verdict can be used. override_applies discards the verdict of
+# an entry that already failed, so running the framework there would execute
+# the code of a repository the dependency source policy refused to execute,
+# spend a container timeout on a clone that may not exist, and publish case
+# counts from a probe whose result was thrown away.
+framework_runs() {
+	local mode="$1" pre_status="$2"
+	if [[ "${mode}" == "render-only" ]] || [[ "${pre_status}" != "pass" ]]; then
+		echo "no"
+		return 0
+	fi
+	echo "yes"
+}
+
 # Run the pinned framework against one clone, writing its JSON into the log
 # directory so it travels with the logs the entry already publishes.
 #
@@ -101,13 +117,19 @@ fi
 # generates, which are markdown with shortcode invocations and no executable
 # cells, so they need no packages and mount no cache: that keeps them out of
 # the one surface shared between repositories.
+#
+# The root is the clone root, not the render directory. detect_test_mode reads
+# repository-root paths, and for a project entry the render directory is the
+# project path below it, holding neither _extensions/ nor tests/. Rooting here
+# keeps the framework looking where the mode was decided.
 run_framework() {
-	local mode="$1" workdir="$2" log_dir="$3" render_dir="$4" shard="$5" pre_status="$6"
+	local mode="$1" workdir="$2" log_dir="$3" shard="$4" pre_status="$5"
+	local repo_root="${workdir}/repo"
 	local tests_dir layers mount_cache
 
 	case "${mode}" in
 	suite)
-		tests_dir="${render_dir}/tests"
+		tests_dir="${repo_root}/tests"
 		layers=(--layer conformance --layer render --layer smoke)
 		mount_cache="yes"
 		;;
@@ -131,19 +153,20 @@ run_framework() {
 
 	# A repository that has already failed the dependency source policy or a
 	# dependency install has not earned write access to a cache shared with
-	# every other repository in this job. This costs nothing real, because
-	# override_applies already refuses a non-pass pre-status, so this run's
-	# verdict was never going to be used anyway.
+	# every other repository in this job. framework_runs already refuses to
+	# call this function for such an entry; the shared cache is the one channel
+	# between repositories, so it keeps its own guard rather than trusting a
+	# caller to hold the line.
 	if [[ "${pre_status}" != "pass" ]]; then
 		mount_cache="no"
 	fi
 
-	docker_run_render "${FRAMEWORK_TIMEOUT}" "${workdir}" "${log_dir}" "${render_dir}" "${shard}" "${mount_cache}" \
+	docker_run_render "${FRAMEWORK_TIMEOUT}" "${workdir}" "${log_dir}" "${repo_root}" "${shard}" "${mount_cache}" \
 		-v "${FRAMEWORK_DIR}:${FRAMEWORK_DIR}:ro" \
 		<<-EOF || true
 			set -uo pipefail
 			quarto pandoc lua "${FRAMEWORK_RUNNER}" \
-				--root "${render_dir}" \
+				--root "${repo_root}" \
 				--tests "${tests_dir}" \
 				--json "${log_dir}/extension-test.json" \
 				--tap /dev/null \
@@ -343,8 +366,8 @@ render_extension() {
 	fw_fail=0
 	fw_skip=0
 	fw_rendered=0
-	if [[ "${test_mode}" != "render-only" ]] && [[ "${status}" != "skip" ]]; then
-		run_framework "${test_mode}" "${workdir}" "${log_dir}" "${render_dir}" "${shard}" "${pre_framework_status}"
+	if [[ "$(framework_runs "${test_mode}" "${pre_framework_status}")" == "yes" ]]; then
+		run_framework "${test_mode}" "${workdir}" "${log_dir}" "${shard}" "${pre_framework_status}"
 		# The fallback branches of framework_verdict always emit a trailing
 		# newline, but `|| true` keeps this shard alive even if a future change
 		# to that contract lets a delimiter-less read hit EOF again.

--- a/.github/scripts/test-extensions/render-extensions.sh
+++ b/.github/scripts/test-extensions/render-extensions.sh
@@ -83,7 +83,7 @@ readonly FRAMEWORK_TIMEOUT=600
 # cells, so they need no packages and mount no cache: that keeps them out of
 # the one surface shared between repositories.
 run_framework() {
-	local mode="$1" workdir="$2" log_dir="$3" render_dir="$4" shard="$5"
+	local mode="$1" workdir="$2" log_dir="$3" render_dir="$4" shard="$5" pre_status="$6"
 	local tests_dir layers mount_cache
 
 	case "${mode}" in
@@ -112,6 +112,15 @@ run_framework() {
 		return 0
 		;;
 	esac
+
+	# A repository that has already failed the dependency source policy or a
+	# dependency install has not earned write access to a cache shared with
+	# every other repository in this job. This costs nothing real: override_
+	# applies already refuses a non-pass pre-status, so this run's verdict was
+	# never going to be used anyway.
+	if [[ "${pre_status}" != "pass" ]]; then
+		mount_cache="no"
+	fi
 
 	docker_run_render "${FRAMEWORK_TIMEOUT}" "${workdir}" "${log_dir}" "${render_dir}" "${shard}" "${mount_cache}" \
 		-v "${FRAMEWORK_DIR}:${FRAMEWORK_DIR}:ro" \
@@ -314,7 +323,7 @@ render_extension() {
 	fw_skip=0
 	fw_rendered=0
 	if [[ "${test_mode}" != "render-only" ]] && [[ "${status}" != "skip" ]]; then
-		run_framework "${test_mode}" "${workdir}" "${log_dir}" "${render_dir}" "${shard}"
+		run_framework "${test_mode}" "${workdir}" "${log_dir}" "${render_dir}" "${shard}" "${pre_framework_status}"
 		# The fallback branches of framework_verdict always emit a trailing
 		# newline, but `|| true` keeps this shard alive even if a future change
 		# to that contract lets a delimiter-less read hit EOF again.

--- a/.github/scripts/test-extensions/tests/classify.test.sh
+++ b/.github/scripts/test-extensions/tests/classify.test.sh
@@ -62,5 +62,10 @@ check 'document classification is unchanged' \
 	'{"type":"document","qmd_files":["example.qmd"]}' \
 	"$(printf 'example.qmd\n' | classify_extension_tree)"
 
+# A template or example entry is never classified, so it must default rather
+# than inherit whatever the last entry had.
+check 'an unclassified entry defaults to render-only' 'render-only' \
+	"$(printf '%s' '{"id":"o/r","type":"template"}' | jq -r '.test_mode // "render-only"')"
+
 printf '\n%d checks, %d failed\n' "$((passed + failed))" "${failed}"
 [[ "${failed}" -eq 0 ]]

--- a/.github/scripts/test-extensions/tests/classify.test.sh
+++ b/.github/scripts/test-extensions/tests/classify.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Tests for classify-extension.sh. Run directly: tests/classify.test.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${HERE}/../classify-extension.sh"
+
+passed=0
+failed=0
+
+check() {
+	local description="$1" expected="$2" actual="$3"
+	if [[ "${expected}" == "${actual}" ]]; then
+		passed=$((passed + 1))
+		printf 'ok   %s\n' "${description}"
+	else
+		failed=$((failed + 1))
+		printf 'FAIL %s\n     expected %s, got %s\n' "${description}" "${expected}" "${actual}"
+	fi
+}
+
+mode_of() {
+	printf '%s\n' "$1" | detect_test_mode
+}
+
+SUITE_TREE='_extensions/demo/_extension.yml
+_extensions/demo/demo.lua
+tests/_quarto.yml
+tests/basic.qmd'
+
+SCHEMA_TREE='_extensions/demo/_extension.yml
+_extensions/demo/_schema.yml
+example.qmd'
+
+MANIFEST_ONLY_TREE='_extensions/demo/_extension.yml
+example.qmd'
+
+NO_EXTENSION_TREE='README.md
+template.qmd'
+
+# A tests directory holding no document is not a suite.
+EMPTY_SUITE_TREE='_extensions/demo/_extension.yml
+tests/_quarto.yml'
+
+# An installed copy under docs/ is not this repository's own extension.
+INSTALLED_COPY_TREE='docs/_extensions/mcanouil/other/_extension.yml
+README.md'
+
+check 'a tests project with a document is a suite' 'suite' "$(mode_of "${SUITE_TREE}")"
+check 'a schema without a suite is schema mode' 'schema' "$(mode_of "${SCHEMA_TREE}")"
+check 'a manifest alone is conformance mode' 'conformance' "$(mode_of "${MANIFEST_ONLY_TREE}")"
+check 'no extension manifest is render-only' 'render-only' "$(mode_of "${NO_EXTENSION_TREE}")"
+check 'a tests project with no document is not a suite' 'conformance' "$(mode_of "${EMPTY_SUITE_TREE}")"
+check 'an installed copy under docs is not an extension' 'render-only' "$(mode_of "${INSTALLED_COPY_TREE}")"
+
+# The existing contract must not move: preflight-render.sh shares this file.
+check 'project classification is unchanged' \
+	'{"type":"project","project_path":"."}' \
+	"$(printf '_quarto.yml\nindex.qmd\n' | classify_extension_tree)"
+check 'document classification is unchanged' \
+	'{"type":"document","qmd_files":["example.qmd"]}' \
+	"$(printf 'example.qmd\n' | classify_extension_tree)"
+
+printf '\n%d checks, %d failed\n' "$((passed + failed))" "${failed}"
+[[ "${failed}" -eq 0 ]]

--- a/.github/scripts/test-extensions/tests/classify.test.sh
+++ b/.github/scripts/test-extensions/tests/classify.test.sh
@@ -63,9 +63,13 @@ check 'document classification is unchanged' \
 	"$(printf 'example.qmd\n' | classify_extension_tree)"
 
 # A template or example entry is never classified, so it must default rather
-# than inherit whatever the last entry had.
-check 'an unclassified entry defaults to render-only' 'render-only' \
-	"$(printf '%s' '{"id":"o/r","type":"template"}' | jq -r '.test_mode // "render-only"')"
+# than inherit whatever the last entry had. An entry that already carries a
+# test_mode (set by phase B, or by a future caller) must keep it.
+STAMP_INPUT='[{"id":"o/r","type":"template"},{"id":"o/s","type":"example","test_mode":"schema"}]'
+STAMP_EXPECTED='[{"id":"o/r","type":"template","test_mode":"render-only"},{"id":"o/s","type":"example","test_mode":"schema"}]'
+check 'stamp_default_test_mode adds the default without overwriting an existing mode' \
+	"$(printf '%s' "${STAMP_EXPECTED}" | jq -Sc '.')" \
+	"$(printf '%s' "${STAMP_INPUT}" | stamp_default_test_mode | jq -Sc '.')"
 
 printf '\n%d checks, %d failed\n' "$((passed + failed))" "${failed}"
 [[ "${failed}" -eq 0 ]]

--- a/.github/scripts/test-extensions/tests/framework.test.sh
+++ b/.github/scripts/test-extensions/tests/framework.test.sh
@@ -56,6 +56,20 @@ project_only=$(write_fixture project_only '{"status":"pass",
 check 'a run that rendered nothing reports zero rendered' 'pass	4	3	0	1	0' \
 	"$(framework_verdict "${project_only}")"
 
+# The caller never reads framework_verdict through $( ); it reads it through
+# `IFS=$'\t' read -r ... < <(framework_verdict ...)`. Command substitution
+# strips a missing trailing newline, so a check built on $( ) cannot see a
+# fallback that forgets one: it must go through the same process-substitution
+# form the caller uses, or the read hitting EOF without a delimiter (and, under
+# `set -euo pipefail`, aborting the whole calling function) stays invisible.
+missing_read_status=0
+IFS=$'\t' read -r missing_status missing_total missing_pass missing_fail missing_skip missing_rendered < <(
+	framework_verdict "${FIXTURES}/absent.json"
+) || missing_read_status=$?
+check 'reading a missing-file verdict through process substitution succeeds' '0' "${missing_read_status}"
+check 'a missing-file verdict yields six fields via process substitution' 'none	0	0	0	0	0' \
+	"$(printf '%s\t%s\t%s\t%s\t%s\t%s' "${missing_status}" "${missing_total}" "${missing_pass}" "${missing_fail}" "${missing_skip}" "${missing_rendered}")"
+
 eval "$(sed -n '/^framework_decides()/,/^}/p' "${HERE}/../render-extensions.sh")"
 
 # The framework speaks for an entry only where it actually rendered, and only

--- a/.github/scripts/test-extensions/tests/framework.test.sh
+++ b/.github/scripts/test-extensions/tests/framework.test.sh
@@ -141,5 +141,17 @@ captured_mount_cache=""
 run_framework suite "${FIXTURES}/workdir" "${FIXTURES}/logdir" "${FIXTURES}/renderdir" 0 fail
 check 'a policy or dependency failure loses the shared cache in suite mode' 'no' "${captured_mount_cache}"
 
+eval "$(sed -n '/^count_renders()/,/^}/p' "${HERE}/../render-extensions.sh")"
+
+# A framework failure sets status="fail" with stage="extension-test", not
+# stage="render", even though render_extension had already run the render
+# before the framework decided the entry. The count must not drop that entry:
+# doing so both under-reports "Rendered N/M" and can trip the "no render was
+# executed" error over a batch that failed wholesale through the framework.
+extension_test_stage=$(write_fixture extension_test_stage '[{"status":"fail","stage":"extension-test"}]')
+clone_stage=$(write_fixture clone_stage '[{"status":"fail","stage":"clone"}]')
+check 'an extension-test failure is counted as a render' '1' "$(count_renders "${extension_test_stage}")"
+check 'a clone failure is not counted as a render' '0' "$(count_renders "${clone_stage}")"
+
 printf '\n%d checks, %d failed\n' "$((passed + failed))" "${failed}"
 [[ "${failed}" -eq 0 ]]

--- a/.github/scripts/test-extensions/tests/framework.test.sh
+++ b/.github/scripts/test-extensions/tests/framework.test.sh
@@ -56,5 +56,25 @@ project_only=$(write_fixture project_only '{"status":"pass",
 check 'a run that rendered nothing reports zero rendered' 'pass	4	3	0	1	0' \
 	"$(framework_verdict "${project_only}")"
 
+eval "$(sed -n '/^framework_decides()/,/^}/p' "${HERE}/../render-extensions.sh")"
+
+# The framework speaks for an entry only where it actually rendered, and only
+# when it reached a verdict. An all-skip run exits 0 and would otherwise be
+# read as a clean pass, which is how a layer comes to assert nothing inside a
+# run that says PASS.
+check 'suite mode with failures is decided by the framework' 'yes' "$(framework_decides suite fail 2 5)"
+check 'schema mode with passes is decided by the framework' 'yes' "$(framework_decides schema pass 0 4)"
+check 'an all-skip suite run falls back to the render' 'no' "$(framework_decides suite skip 0 0)"
+check 'a framework that did not run falls back' 'no' "$(framework_decides suite none 0 0)"
+check 'conformance mode never decides the status' 'no' "$(framework_decides conformance fail 3 0)"
+check 'render-only mode never decides the status' 'no' "$(framework_decides render-only fail 3 0)"
+
+# The regression this rule exists to prevent. An extension contributing only a
+# project type passes conformance and skips its only smoke case, so the run
+# reports pass. Taking that verdict would mark the entry green and skip the
+# render it gets today, asserting nothing.
+check 'a pass that rendered nothing falls back to the render' 'no' \
+	"$(framework_decides schema pass 0 0)"
+
 printf '\n%d checks, %d failed\n' "$((passed + failed))" "${failed}"
 [[ "${failed}" -eq 0 ]]

--- a/.github/scripts/test-extensions/tests/framework.test.sh
+++ b/.github/scripts/test-extensions/tests/framework.test.sh
@@ -22,6 +22,16 @@ eval_function() {
 		printf 'FAIL could not extract %s() from render-extensions.sh\n' "${name}" >&2
 		exit 1
 	fi
+	# The range ends at the first column-zero brace, which is the function's
+	# own closing brace today. A here-document body or an embedded jq or awk
+	# program could put one there first and end the range early, and a
+	# truncated body can still define a shorter, wrong function that every
+	# later check would then validate. Parsing it first rejects that: a cut
+	# leaves an unterminated here-document, quote or block behind.
+	if ! bash -n <<<"${body}" 2>/dev/null; then
+		printf 'FAIL extraction of %s() is truncated or unparseable\n' "${name}" >&2
+		exit 1
+	fi
 	eval "${body}"
 }
 
@@ -190,6 +200,24 @@ check 'a passing entry in schema mode runs the framework' 'yes' "$(framework_run
 check 'a render-only entry never runs the framework' 'no' "$(framework_runs render-only pass)"
 check 'a failed entry never runs the framework' 'no' "$(framework_runs suite fail)"
 check 'a skipped entry never runs the framework' 'no' "$(framework_runs conformance skip)"
+
+eval_function framework_required
+
+# The runner-presence guard must not fire for a batch that never calls the
+# framework. check-extensions/preflight-render.sh runs this same script for a
+# pull request, its workflow does not check the framework out, and it
+# swallows a non-zero exit into a warning: an unconditional guard there
+# aborts before the first entry renders, results.json is never written, and a
+# blocking preflight reports no failure at all.
+no_framework=$(write_fixture no_framework '[{"ext":{"test_mode":"render-only"}},{"ext":{}}]')
+one_framework=$(write_fixture one_framework '[{"ext":{"test_mode":"render-only"}},{"ext":{"test_mode":"schema"}}]')
+empty_batch=$(write_fixture empty_batch '[]')
+check 'a batch of render-only entries does not require the runner' 'no' \
+	"$(framework_required "${no_framework}")"
+check 'a batch missing test_mode entirely does not require the runner' 'no' \
+	"$(framework_required "${empty_batch}")"
+check 'a single non-render-only entry requires the runner' 'yes' \
+	"$(framework_required "${one_framework}")"
 
 eval_function count_renders
 

--- a/.github/scripts/test-extensions/tests/framework.test.sh
+++ b/.github/scripts/test-extensions/tests/framework.test.sh
@@ -6,9 +6,26 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURES="$(mktemp -d)"
 trap 'rm -rf "${FIXTURES}"' EXIT
 
-# Only the reader is under test, so it is sourced out of the script rather
-# than running the whole sweep.
-eval "$(sed -n '/^framework_verdict()/,/^}/p' "${HERE}/../render-extensions.sh")"
+# Only the individual predicates are under test, so each is lifted out of the
+# script rather than running the whole sweep. A rename, or a column-zero brace
+# inside a body, would otherwise yield an empty or truncated extraction that
+# eval accepts in silence, leaving every check that follows it testing a stale
+# definition or nothing at all. Fail on the spot instead.
+#
+# The eval happens here rather than in a command substitution at the call
+# site, because `exit` inside `$( )` ends only the subshell: the empty body
+# would still reach eval and the run would carry on regardless.
+eval_function() {
+	local name="$1" body
+	body=$(sed -n "/^${name}()/,/^}/p" "${HERE}/../render-extensions.sh")
+	if [[ -z "${body}" ]]; then
+		printf 'FAIL could not extract %s() from render-extensions.sh\n' "${name}" >&2
+		exit 1
+	fi
+	eval "${body}"
+}
+
+eval_function framework_verdict
 
 passed=0
 failed=0
@@ -81,7 +98,7 @@ check 'reading a missing-file verdict through process substitution succeeds' '0'
 check 'a missing-file verdict yields six fields via process substitution' 'none	0	0	0	0	0' \
 	"$(printf '%s\t%s\t%s\t%s\t%s\t%s' "${missing_status}" "${missing_total}" "${missing_pass}" "${missing_fail}" "${missing_skip}" "${missing_rendered}")"
 
-eval "$(sed -n '/^framework_decides()/,/^}/p' "${HERE}/../render-extensions.sh")"
+eval_function framework_decides
 
 # The framework speaks for an entry only where it actually rendered, and only
 # when it reached a verdict. An all-skip run exits 0 and would otherwise be
@@ -101,7 +118,7 @@ check 'render-only mode never decides the status' 'no' "$(framework_decides rend
 check 'a pass that rendered nothing falls back to the render' 'no' \
 	"$(framework_decides schema pass 0 0)"
 
-eval "$(sed -n '/^override_applies()/,/^}/p' "${HERE}/../render-extensions.sh")"
+eval_function override_applies
 
 # The framework may add a failure the render missed, but must never erase one
 # the render already found: a clone, policy, dependency or render failure is a
@@ -111,7 +128,7 @@ check 'a prior failure is never erased by a framework pass' 'no' \
 check 'a prior pass is overridden by the same framework result' 'yes' \
 	"$(override_applies pass schema pass 0 4)"
 
-eval "$(sed -n '/^run_framework()/,/^}/p' "${HERE}/../render-extensions.sh")"
+eval_function run_framework
 
 # run_framework's only externally observable action is the docker_run_render
 # call it makes, so that call is stubbed here to capture the mount_cache it
@@ -130,18 +147,42 @@ FRAMEWORK_MAX_GENERATED=40
 FRAMEWORK_TIMEOUT=600
 
 captured_mount_cache=""
+captured_root=""
 docker_run_render() {
+	captured_root="$4"
 	captured_mount_cache="$6"
 }
 
-run_framework suite "${FIXTURES}/workdir" "${FIXTURES}/logdir" "${FIXTURES}/renderdir" 0 pass
+run_framework suite "${FIXTURES}/workdir" "${FIXTURES}/logdir" 0 pass
 check 'a clean pre-framework status keeps the shared cache in suite mode' 'yes' "${captured_mount_cache}"
 
+# The framework roots at the clone root, which is where detect_test_mode
+# looked. Today's render roots at the project path instead, which for a
+# project entry is a subdirectory holding neither _extensions/ nor tests/.
+# Rooting the framework there would make every such entry probe a tree with
+# no extension in it, all-skip, and fall back, while the catalogue published
+# a mode the entry could never exercise.
+check 'the framework roots at the clone root, not the render directory' \
+	"${FIXTURES}/workdir/repo" "${captured_root}"
+
 captured_mount_cache=""
-run_framework suite "${FIXTURES}/workdir" "${FIXTURES}/logdir" "${FIXTURES}/renderdir" 0 fail
+run_framework suite "${FIXTURES}/workdir" "${FIXTURES}/logdir" 0 fail
 check 'a policy or dependency failure loses the shared cache in suite mode' 'no' "${captured_mount_cache}"
 
-eval "$(sed -n '/^count_renders()/,/^}/p' "${HERE}/../render-extensions.sh")"
+eval_function framework_runs
+
+# The framework runs only where its verdict can be used. override_applies
+# discards the verdict of an entry that already failed, so running it anyway
+# executes the code of a repository the pipeline deliberately refused to
+# execute, burns a container timeout on a clone that does not exist, and
+# publishes case counts from a probe whose result was thrown away.
+check 'a passing entry in suite mode runs the framework' 'yes' "$(framework_runs suite pass)"
+check 'a passing entry in schema mode runs the framework' 'yes' "$(framework_runs schema pass)"
+check 'a render-only entry never runs the framework' 'no' "$(framework_runs render-only pass)"
+check 'a failed entry never runs the framework' 'no' "$(framework_runs suite fail)"
+check 'a skipped entry never runs the framework' 'no' "$(framework_runs conformance skip)"
+
+eval_function count_renders
 
 # A framework failure sets status="fail" with stage="extension-test", not
 # stage="render", even though render_extension had already run the render

--- a/.github/scripts/test-extensions/tests/framework.test.sh
+++ b/.github/scripts/test-extensions/tests/framework.test.sh
@@ -100,5 +100,35 @@ check 'a prior failure is never erased by a framework pass' 'no' \
 check 'a prior pass is overridden by the same framework result' 'yes' \
 	"$(override_applies pass schema pass 0 4)"
 
+eval "$(sed -n '/^run_framework()/,/^}/p' "${HERE}/../render-extensions.sh")"
+
+# run_framework's only externally observable action is the docker_run_render
+# call it makes, so that call is stubbed here to capture the mount_cache it
+# was given rather than run for real: this proves the decision without a
+# container. The constants below stand in for the readonly ones
+# render-extensions.sh sets at top level, which this eval does not pick up.
+# Read by the eval'd run_framework body, which shellcheck cannot see through
+# the sed extraction above.
+# shellcheck disable=SC2034
+FRAMEWORK_DIR="${FIXTURES}/framework"
+# shellcheck disable=SC2034
+FRAMEWORK_RUNNER="${FRAMEWORK_DIR}/_extensions/extension-test/run.lua"
+# shellcheck disable=SC2034
+FRAMEWORK_MAX_GENERATED=40
+# shellcheck disable=SC2034
+FRAMEWORK_TIMEOUT=600
+
+captured_mount_cache=""
+docker_run_render() {
+	captured_mount_cache="$6"
+}
+
+run_framework suite "${FIXTURES}/workdir" "${FIXTURES}/logdir" "${FIXTURES}/renderdir" 0 pass
+check 'a clean pre-framework status keeps the shared cache in suite mode' 'yes' "${captured_mount_cache}"
+
+captured_mount_cache=""
+run_framework suite "${FIXTURES}/workdir" "${FIXTURES}/logdir" "${FIXTURES}/renderdir" 0 fail
+check 'a policy or dependency failure loses the shared cache in suite mode' 'no' "${captured_mount_cache}"
+
 printf '\n%d checks, %d failed\n' "$((passed + failed))" "${failed}"
 [[ "${failed}" -eq 0 ]]

--- a/.github/scripts/test-extensions/tests/framework.test.sh
+++ b/.github/scripts/test-extensions/tests/framework.test.sh
@@ -76,5 +76,15 @@ check 'render-only mode never decides the status' 'no' "$(framework_decides rend
 check 'a pass that rendered nothing falls back to the render' 'no' \
 	"$(framework_decides schema pass 0 0)"
 
+eval "$(sed -n '/^override_applies()/,/^}/p' "${HERE}/../render-extensions.sh")"
+
+# The framework may add a failure the render missed, but must never erase one
+# the render already found: a clone, policy, dependency or render failure is a
+# fact about the entry that a later, decoupled probe cannot disprove.
+check 'a prior failure is never erased by a framework pass' 'no' \
+	"$(override_applies fail schema pass 0 4)"
+check 'a prior pass is overridden by the same framework result' 'yes' \
+	"$(override_applies pass schema pass 0 4)"
+
 printf '\n%d checks, %d failed\n' "$((passed + failed))" "${failed}"
 [[ "${failed}" -eq 0 ]]

--- a/.github/scripts/test-extensions/tests/framework.test.sh
+++ b/.github/scripts/test-extensions/tests/framework.test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Tests for the framework verdict reader in render-extensions.sh.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES="$(mktemp -d)"
+trap 'rm -rf "${FIXTURES}"' EXIT
+
+# Only the reader is under test, so it is sourced out of the script rather
+# than running the whole sweep.
+eval "$(sed -n '/^framework_verdict()/,/^}/p' "${HERE}/../render-extensions.sh")"
+
+passed=0
+failed=0
+check() {
+	local description="$1" expected="$2" actual="$3"
+	if [[ "${expected}" == "${actual}" ]]; then
+		passed=$((passed + 1))
+		printf 'ok   %s\n' "${description}"
+	else
+		failed=$((failed + 1))
+		printf 'FAIL %s\n     expected %s, got %s\n' "${description}" "${expected}" "${actual}"
+	fi
+}
+
+write_fixture() {
+	printf '%s' "$2" >"${FIXTURES}/$1.json"
+	printf '%s' "${FIXTURES}/$1.json"
+}
+
+passing=$(write_fixture passing '{"status":"pass","summary":{"total":3,"pass":3,"fail":0,"skip":0},"layers":{"conformance":{"total":1,"pass":1,"fail":0,"skip":0},"render":{"total":2,"pass":2,"fail":0,"skip":0}}}')
+failing=$(write_fixture failing '{"status":"fail","summary":{"total":3,"pass":1,"fail":2,"skip":0},"layers":{"render":{"total":3,"pass":1,"fail":2,"skip":0}}}')
+allskip=$(write_fixture allskip '{"status":"skip","summary":{"total":2,"pass":0,"fail":0,"skip":2}}')
+# An empty Lua table encodes as an object, not an array, so summary can arrive
+# as {} and every field must default rather than read as null.
+empty=$(write_fixture empty '{"status":"skip","summary":{}}')
+
+check 'a passing run reports its counts' 'pass	3	3	0	0	2' "$(framework_verdict "${passing}")"
+check 'a failing run reports its counts' 'fail	3	1	2	0	3' "$(framework_verdict "${failing}")"
+check 'an all-skip run is reported as skip' 'skip	2	0	0	2	0' "$(framework_verdict "${allskip}")"
+check 'an empty summary defaults to zeroes' 'skip	0	0	0	0	0' "$(framework_verdict "${empty}")"
+check 'a missing file reports none' 'none	0	0	0	0	0' "$(framework_verdict "${FIXTURES}/absent.json")"
+check 'unparseable JSON reports none' 'none	0	0	0	0	0' "$(
+	write_fixture broken 'not json' >/dev/null
+	framework_verdict "${FIXTURES}/broken.json"
+)"
+
+# An extension contributing only a project type is the case that matters here.
+# generate.lua names a contributed project type as a gap rather than
+# half-generating it, so conformance passes, smoke only skips, and the run
+# reports pass having rendered nothing at all.
+project_only=$(write_fixture project_only '{"status":"pass",
+  "summary":{"total":4,"pass":3,"fail":0,"skip":1},
+  "layers":{"conformance":{"total":3,"pass":3,"fail":0,"skip":0},
+            "smoke":{"total":1,"pass":0,"fail":0,"skip":1}}}')
+check 'a run that rendered nothing reports zero rendered' 'pass	4	3	0	1	0' \
+	"$(framework_verdict "${project_only}")"
+
+printf '\n%d checks, %d failed\n' "$((passed + failed))" "${failed}"
+[[ "${failed}" -eq 0 ]]

--- a/.github/scripts/test-extensions/tests/framework.test.sh
+++ b/.github/scripts/test-extensions/tests/framework.test.sh
@@ -56,6 +56,17 @@ project_only=$(write_fixture project_only '{"status":"pass",
 check 'a run that rendered nothing reports zero rendered' 'pass	4	3	0	1	0' \
 	"$(framework_verdict "${project_only}")"
 
+# The framework's JSON is written inside the container by the repository's
+# own extension, so a repository can put anything there. Only a bounded enum
+# and four integers may reach the published catalogue: a string, a boolean
+# and an array must all default to zero rather than travel through @tsv and
+# later --argjson into a field the design promises is numeric.
+hostile=$(write_fixture hostile '{"status":"pass",
+  "summary":{"total":"5","pass":true,"fail":[1,2,3],"skip":0},
+  "layers":{"render":{"total":2,"pass":"2","fail":false,"skip":0}}}')
+check 'a repository-supplied string, boolean and array default to zero' 'pass	0	0	0	0	0' \
+	"$(framework_verdict "${hostile}")"
+
 # The caller never reads framework_verdict through $( ); it reads it through
 # `IFS=$'\t' read -r ... < <(framework_verdict ...)`. Command substitution
 # strips a missing trailing newline, so a check built on $( ) cannot see a

--- a/.github/scripts/test-extensions/tests/framework.test.sh
+++ b/.github/scripts/test-extensions/tests/framework.test.sh
@@ -84,6 +84,15 @@ hostile=$(write_fixture hostile '{"status":"pass",
 check 'a repository-supplied string, boolean and array default to zero' 'pass	0	0	0	0	0' \
 	"$(framework_verdict "${hostile}")"
 
+# `numbers` admits any JSON number, so a fraction, a negative and a huge
+# exponent are all still numbers and would travel through unchanged into a
+# published field the design describes as a bounded integer.
+unbounded=$(write_fixture unbounded '{"status":"pass",
+  "summary":{"total":1.5,"pass":-3,"fail":1e308,"skip":0.9},
+  "layers":{"render":{"total":2,"pass":2.7,"fail":-1,"skip":0}}}')
+check 'a fraction, a negative and a huge count are bounded to integers' 'pass	1	0	1000000	0	2' \
+	"$(framework_verdict "${unbounded}")"
+
 # The caller never reads framework_verdict through $( ); it reads it through
 # `IFS=$'\t' read -r ... < <(framework_verdict ...)`. Command substitution
 # strips a missing trailing newline, so a check built on $( ) cannot see a

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -153,6 +153,16 @@ jobs:
           sparse-checkout: .github/scripts/test-extensions
           sparse-checkout-cone-mode: false
 
+      # The catalogue runs one pinned framework version against every entry, so
+      # results are comparable and an upgrade is a single reviewable change.
+      - name: Checkout the test framework
+        uses: actions/checkout@v7
+        with:
+          repository: mcanouil/quarto-extension-test
+          ref: "0.1.0"
+          path: extension-test
+          persist-credentials: false
+
       - name: Write extensions batch to file
         env:
           EXTENSIONS_JSON: ${{ toJSON(matrix.extensions) }}

--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -155,11 +155,16 @@ jobs:
 
       # The catalogue runs one pinned framework version against every entry, so
       # results are comparable and an upgrade is a single reviewable change.
+      # The ref is the tag's commit rather than the tag, because this code is
+      # mounted into the container that runs third-party extensions and a
+      # moved tag would change it without a change here. The image the same
+      # container runs is digest pinned for the same reason.
       - name: Checkout the test framework
         uses: actions/checkout@v7
         with:
           repository: mcanouil/quarto-extension-test
-          ref: "0.1.0"
+          # Tag 0.1.0
+          ref: "09e2dc09029ee8662f01976846dd88fc204952c5"
           path: extension-test
           persist-credentials: false
 

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,35 @@
+name: Test Scripts
+
+# The sweep runs once a month, so a regression in the classification or
+# verdict logic would otherwise stay hidden until it misreports a whole
+# catalogue. These checks need no container and no Quarto, and run in
+# seconds, so they run on every change to the scripts they cover.
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/scripts/test-extensions/**"
+      - ".github/workflows/test-scripts.yml"
+  pull_request:
+    paths:
+      - ".github/scripts/test-extensions/**"
+      - ".github/workflows/test-scripts.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts/test-extensions
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Run the script tests
+        run: |
+          .github/scripts/test-extensions/tests/classify.test.sh
+          .github/scripts/test-extensions/tests/framework.test.sh

--- a/assets/scripts/build-index.sh
+++ b/assets/scripts/build-index.sh
@@ -76,7 +76,7 @@ jq -n \
                 status: .status,
                 log: .log,
                 date: .date,
-                mode: .test_mode,
+                mode: (.test_mode // "render-only"),
                 cases: .cases
               }
           ]

--- a/assets/scripts/build-index.sh
+++ b/assets/scripts/build-index.sh
@@ -75,7 +75,9 @@ jq -n \
                 channel: .quarto_channel,
                 status: .status,
                 log: .log,
-                date: .date
+                date: .date,
+                mode: .test_mode,
+                cases: .cases
               }
           ]
         }

--- a/assets/scripts/quarto-extensions-listing.html
+++ b/assets/scripts/quarto-extensions-listing.html
@@ -405,6 +405,10 @@
               <td>${result.channel === 'prerelease' ? 'Pre-release' : 'Release'}</td>
               <td><i class="bi ${icon}" aria-hidden="true"></i> ${escapeHtml(result.status)}</td>
               <td>${escapeHtml(result.date)}</td>
+              <td>${escapeHtml(result.mode || 'render-only')}</td>
+              <td>${result.cases
+                ? `${escapeHtml(String(result.cases.pass))}/${escapeHtml(String(result.cases.total))}`
+                : '&mdash;'}</td>
               <td><a href="${escapeHtml(logUrl)}" target="_blank" rel="noopener noreferrer">Log</a></td>
             </tr>`;
           }).join('');
@@ -412,7 +416,7 @@
           title: `Test history for ${item.title}`,
           body: `<table class="table table-sm align-middle mb-0">
             <thead><tr><th scope="col">Quarto</th><th scope="col">Channel</th><th scope="col">Status</th>
-              <th scope="col">Date</th><th scope="col">Log</th></tr></thead>
+              <th scope="col">Date</th><th scope="col">Mode</th><th scope="col">Cases</th><th scope="col">Log</th></tr></thead>
             <tbody>${rows}</tbody>
           </table>`
         };

--- a/assets/scripts/quarto-extensions-listing.html
+++ b/assets/scripts/quarto-extensions-listing.html
@@ -406,7 +406,7 @@
               <td><i class="bi ${icon}" aria-hidden="true"></i> ${escapeHtml(result.status)}</td>
               <td>${escapeHtml(result.date)}</td>
               <td>${escapeHtml(result.mode || 'render-only')}</td>
-              <td>${result.cases
+              <td>${result.cases && result.cases.total > 0
                 ? `${escapeHtml(String(result.cases.pass))}/${escapeHtml(String(result.cases.total))}`
                 : '&mdash;'}</td>
               <td><a href="${escapeHtml(logUrl)}" target="_blank" rel="noopener noreferrer">Log</a></td>

--- a/assets/scripts/quarto-extensions-listing.html
+++ b/assets/scripts/quarto-extensions-listing.html
@@ -406,9 +406,17 @@
               <td><i class="bi ${icon}" aria-hidden="true"></i> ${escapeHtml(result.status)}</td>
               <td>${escapeHtml(result.date)}</td>
               <td>${escapeHtml(result.mode || 'render-only')}</td>
-              <td>${result.cases && result.cases.total > 0
-                ? `${escapeHtml(String(result.cases.pass))}/${escapeHtml(String(result.cases.total))}`
-                : '&mdash;'}</td>
+              <td>${(() => {
+                // Counted against the cases the run decided, not its total:
+                // a skip is not a case that failed. An all-skip run would
+                // otherwise read as 0/N beside a green pass, which says every
+                // case failed when none of them ran.
+                const cases = result.cases;
+                if (!cases) return '&mdash;';
+                const decided = (cases.pass || 0) + (cases.fail || 0);
+                if (decided === 0) return '&mdash;';
+                return `${escapeHtml(String(cases.pass || 0))}/${escapeHtml(String(decided))}`;
+              })()}</td>
               <td><a href="${escapeHtml(logUrl)}" target="_blank" rel="noopener noreferrer">Log</a></td>
             </tr>`;
           }).join('');


### PR DESCRIPTION
The monthly sweep renders every listed extension and records whether the render exited zero. It guesses what to render and asserts nothing else, so an extension whose shortcode silently stops expanding still passes.

This runs a pinned copy of `quarto-extension-test` at tag `0.1.0` against each entry, inside the container the sweep already uses, and takes its verdict where that framework actually renders.

Each entry falls into one of four modes, decided from its file tree:

| Mode | Condition | Decides `status` |
| --- | --- | --- |
| `suite` | has its own tests project | framework |
| `schema` | manifest and a v2 schema, no suite | framework |
| `conformance` | manifest only | today's render |
| `render-only` | no manifest | today's render, unchanged |

**Replacing the render never means checking less.** The framework decides `status` only where it rendered, only when it reached a verdict, and only when it decided at least one rendering case. It can add a failure the render missed; it can never erase one the render found.

That third condition earns its place. An extension contributing only a project type passes conformance and skips its one smoke case, because the framework declines to generate a project rather than half-generating one. Such a run reports `pass` having rendered nothing.

**Proof it does the thing.** Unmodified `quarto-iconify`: `pass`, 0 failures. With `render_icon()` returning `pandoc.Null()` so the document still renders but emits no icon markup: `fail`, 8 failures, render layer 2/2 and smoke 6/6. Today's check stays green on exactly that.

**Two properties the sandbox keeps.** The shared package cache is mounted only for `suite` mode, and never for a repository that already failed the dependency-source policy or its dependency install. Otherwise that repository's `pre-render` hooks could install from the sources the policy exists to refuse, into a cache shared with unrelated repositories in the same job.

Only a bounded mode enum and four integers are published. The framework's `failure.message`, `failure.reason` and case ids all carry repository-chosen text and are never stored. The four counts are coerced with jq's `numbers` filter, because that JSON is written where the repository's own code runs.

In `schema` and `conformance` modes the catalogue supplies its own tests project, so a repository's `tests/_quarto.yml` is never read and its render scripts never run. Verified with a sentinel.

Additive on the wire: existing result fields are untouched, `test_mode` and `cases` are optional everywhere, and the roughly 3015 historical rows that predate them still render.

Verified locally: 9 and 23 checks with 0 failures across two new test scripts; `bash -n` and `shellcheck` on every changed script; `build-index.sh` against the real 370-entry data keeping 20 top-level keys and adding exactly two to `tests[]`.

Nothing runs this in CI until the monthly schedule fires or it is dispatched by hand.
